### PR TITLE
Add lock to CAClient callback

### DIFF
--- a/epicsWS/CAClient.py
+++ b/epicsWS/CAClient.py
@@ -25,7 +25,10 @@ class CAClient:
         if not pvname:
             return
         val = {"value": value, **kwargs}
-        self._latest_value[pvname] = val
+
+        with self._lock:
+            self._latest_value[pvname] = val
+
         self._handle_update(pvname, val)
 
     def subscribe(self, client_id: str, pv_name: str):


### PR DESCRIPTION
_callback() will be called by pyepics background thread, which may preempt subscribe() and unsubscribe() called by asyncio coroutines. Probably, _latest_value needs to be protected by lock.