### PR TITLE
Use epicscorelibs module for pyepics

### DIFF
--- a/epicsWS/CAClient.py
+++ b/epicsWS/CAClient.py
@@ -1,5 +1,10 @@
 from typing import Callable, Dict, Set, Any
 from threading import Lock
+
+try:
+    import epicscorelibs.path.pyepics
+except ImportError:
+    pass
 import epics
 
 


### PR DESCRIPTION
When I started epicsWS on Windows 10 and tried to connect to demo PVs via CA, the program crashed and showed the following error info, which seems to be shared libraries conflict between pyepics and p4p,

<img width="1220" height="633" alt="d0b403390c0f305128608632471baa8d" src="https://github.com/user-attachments/assets/abafc553-eebc-49e3-a115-51d83ba8c199" />

After adding the following lines before "import epics" as suggested by the links below, the problem was gone,
```
try:
    import epicscorelibs.path.pyepics
except ImportError:
    pass
```

Links for reference,
https://epics.anl.gov/tech-talk/2020/msg01579.php
https://github.com/mdavidsaver/epicscorelibs#using-with-pyepics-andor-cothread
