### PR TITLE
Use unprivileged Nginx and non-root ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,19 @@ TECHNICAL_ACCOUNT_USERNAME="weiss-bot"
 TECHNICAL_ACCOUNT_EMAIL="weiss-bot@example.com"
 
 # Microsoft Auth
+# These should be renamed to use generic OAuth2 names
 MS_AUTH_CLIENT_ID="your-ms-client-id-here"
 MS_AUTH_TENANT_ID="your-ms-tenant-id-here"
 MS_AUTH_CLIENT_SECRET="your-ms-client-secret-here"
 
+# Generic OAuth2 configuration
+WEISS_ISSUER="http://localhost:8089/realms/master"
+WEISS_IDENTITY_PROVIDER="oauth"
+
 # Documentation
 # uncomment the following serve docs (requires docs/docker-compose.yml to be running)
 # DOCS_HOSTNAME="docs.example.com" 
+
+# Ports
+HTTP_PORT=80
+HTTPS_PORT=443

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,220 @@ roles.toml
 # certificates
 /nginx/certs/*.pem
 !/nginx/certs/example-*.pem
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN npm install --global corepack@latest && corepack enable pnpm
 RUN pnpm install && pnpm run build
 
 # Production image
-FROM nginx:1.25-alpine AS prod
+FROM nginxinc/nginx-unprivileged:1.29.5-alpine-perl AS prod
 COPY --from=build /app/dist /usr/share/nginx/html
 
 COPY ./nginx/default.http.template  /etc/nginx/conf.d/default.http.template
@@ -32,6 +32,5 @@ COPY ./nginx/default.https.template /etc/nginx/conf.d/default.https.template
 COPY ./nginx/default.docs.template  /etc/nginx/conf.d/default.docs.template
 
 COPY ./nginx/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "${HTTPS_PORT:-443}:8082"
     image: weiss:${DOCKER_TAG:-latest}
     container_name: weiss
-    network_mode: host
     restart: always
     environment:
       NODE_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         GIT_REPO: ${GIT_REPO}
         VITE_APP_VERSION: ${VITE_APP_VERSION}
         VITE_DEMO_MODE: ${VITE_DEMO_MODE}
+    ports:
+      - "8081:8081"
     image: weiss:${VITE_APP_VERSION}
     container_name: weiss
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
         VITE_APP_VERSION: ${VITE_APP_VERSION}
         VITE_DEMO_MODE: ${VITE_DEMO_MODE}
     ports:
-      - "8081:8081"
+      - "${HTTP_PORT:-80}:8081"
+      - "${HTTPS_PORT:-443}:8082"
     image: weiss:${VITE_APP_VERSION}
     container_name: weiss
     network_mode: host

--- a/docs/src/production/https.md
+++ b/docs/src/production/https.md
@@ -15,6 +15,13 @@ openssl req -x509 -newkey rsa:4096 -keyout privkey.pem -out fullchain.pem \
   -days 365 -nodes -subj "/CN=your-server-hostname"
 ```
 
+Since NGINX runs in an unpriviledged container, you may need the following to allow the service to
+read the private key file (101 is the `nginx` UID in the container):
+
+```sh
+sudo chown root:101 /path/to/privkey.pem && sudo chmod 640 /path/to/privkey.pem
+```
+
 Place the files anywhere on the host that the `weiss` container can read (they are mounted
 read-only).
 

--- a/nginx/default.http.template
+++ b/nginx/default.http.template
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 8081 default_server;
     server_name ${APP_HOSTNAME};
 
     root /usr/share/nginx/html;

--- a/nginx/default.https.template
+++ b/nginx/default.https.template
@@ -1,11 +1,11 @@
 # Redirect HTTP to HTTPS
 server {
-    listen 80 default_server;
+    listen 8081 default_server;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 443 ssl default_server;
+    listen 8082 ssl default_server;
     server_name ${APP_HOSTNAME};
 
     ssl_certificate ${SSL_FULLCHAIN};

--- a/nginx/default.https.template
+++ b/nginx/default.https.template
@@ -37,7 +37,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://localhost:8000;
+        proxy_pass http://weiss-api:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -45,7 +45,7 @@ server {
     }
 
     location /ws/ {
-        proxy_pass http://localhost:8080;
+        proxy_pass http://weiss-epicsws:8080;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Since developers might use Podman, or otherwise have SELinux rules on  their workstations preventing them from using root privilege ports, we should map those to less privileged ports, which also acts as a security precaution.