### PR TITLE
build: replace VITE_APP_VERSION env var with build-time git version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+.vscode/
+.idea/
+.github/
+docs/
+backend/
+roles.toml/

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
-GIT_REPO=https://github.com/weiss-controls/weiss.git
-VITE_APP_VERSION=1.0.0
+# FrontEnd settings
 VITE_DEMO_MODE=true
 
 # EPICS environment settings

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,12 +24,10 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare .env
-        run: |
-          cp .env.example .env
-          sed -i "s/^VITE_APP_VERSION=.*/VITE_APP_VERSION=${{ github.event.pull_request.head.sha || github.sha }}/" .env
+        run: cp .env.example .env
 
       - name: Docker Build (Default)
-        run: docker compose -f docker-compose.yml build
+        run: docker compose build
 
       - name: Docker Build (Dev)
         run: docker compose -f docker-compose-dev.yml build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM alpine/git:latest AS source_fetch
-ARG GIT_REPO=https://github.com/weiss-controls/weiss.git
-ARG VITE_APP_VERSION=main
-RUN git clone ${GIT_REPO} /app && cd /app && git checkout ${VITE_APP_VERSION}
-
 # Dev environment
 FROM node:20-alpine AS dev
 WORKDIR /app
-COPY --from=source_fetch /app ./
+COPY . .
+# set /app as safe to allow git interaction on mounted folder
+RUN apk add --no-cache git \
+ && git config --global --add safe.directory /app
 RUN npm install --global corepack@latest && corepack enable pnpm
 RUN pnpm install
 
@@ -15,11 +13,10 @@ CMD pnpm run dev --host
 # Production build
 FROM node:20-alpine AS build
 WORKDIR /app
-ARG VITE_APP_VERSION
-ENV VITE_APP_VERSION=${VITE_APP_VERSION}
 ARG VITE_DEMO_MODE
 ENV VITE_DEMO_MODE=${VITE_DEMO_MODE}
-COPY --from=source_fetch /app ./
+COPY . .
+RUN apk add --no-cache git
 RUN npm install --global corepack@latest && corepack enable pnpm
 RUN pnpm install && pnpm run build
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,20 +3,16 @@ services:
     build:
       context: "."
       target: dev
-      args:
-        GIT_REPO: ${GIT_REPO}
-        VITE_APP_VERSION: ${VITE_APP_VERSION}
     volumes:
       - .:/app # Mount the source code for development
       - /app/node_modules # Prevent host node_modules from interfering
-    image: weiss-dev:${VITE_APP_VERSION}
+    image: weiss-dev:${DOCKER_TAG:-latest}
     container_name: weiss-dev
     network_mode: host
     restart: always
     environment:
       NODE_ENV: development
       VITE_DEMO_MODE: ${VITE_DEMO_MODE:-false}
-      VITE_APP_VERSION: ${VITE_APP_VERSION}
     depends_on:
       - weiss-epicsws-dev
       - weiss-api-dev
@@ -25,7 +21,7 @@ services:
       context: ./backend/epicsWS
     volumes:
       - ./backend/epicsWS:/app
-    image: weiss-epicsws-dev:${VITE_APP_VERSION}
+    image: weiss-epicsws-dev:${DOCKER_TAG:-latest}
     container_name: weiss-epicsws-dev
     ports:
       - "8080:8080"
@@ -45,7 +41,7 @@ services:
       - ./backend/api:/app/api
       - storage:/app/storage
       - ${ROLES_CONFIG_FILE:-./roles.toml}:/config/roles.toml:ro
-    image: weiss-api-dev:${VITE_APP_VERSION}
+    image: weiss-api-dev:${DOCKER_TAG:-latest}
     container_name: weiss-api-dev
     ports:
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,8 @@ services:
       context: "."
       target: prod
       args:
-        GIT_REPO: ${GIT_REPO}
-        VITE_APP_VERSION: ${VITE_APP_VERSION}
         VITE_DEMO_MODE: ${VITE_DEMO_MODE}
-    image: weiss:${VITE_APP_VERSION}
+    image: weiss:${DOCKER_TAG:-latest}
     container_name: weiss
     network_mode: host
     restart: always
@@ -18,7 +16,6 @@ services:
       SSL_KEY_FILE: ${SSL_KEY_FILE:-./nginx/certs/example-privkey.pem}
       APP_HOSTNAME: ${APP_HOSTNAME}
       DOCS_HOSTNAME: ${DOCS_HOSTNAME:-}
-      VITE_APP_VERSION: ${VITE_APP_VERSION}
     volumes:
       - ${SSL_CERT_FILE}:/etc/nginx/certs/fullchain.pem:ro
       - ${SSL_KEY_FILE}:/etc/nginx/certs/privkey.pem:ro
@@ -28,7 +25,7 @@ services:
   weiss-epicsws:
     build:
       context: ./backend/epicsWS
-    image: weiss-epicsws:${VITE_APP_VERSION}
+    image: weiss-epicsws:${DOCKER_TAG:-latest}
     container_name: weiss-epicsws
     ports:
       - "8080:8080"
@@ -47,7 +44,7 @@ services:
     volumes:
       - storage:/app/storage
       - ${ROLES_CONFIG_FILE:-./roles.toml}:/config/roles.toml:ro
-    image: weiss-api:${VITE_APP_VERSION}
+    image: weiss-api:${DOCKER_TAG:-latest}
     container_name: weiss-api
     ports:
       - "8000:8000"

--- a/docs/src/getting_started/quickstart.md
+++ b/docs/src/getting_started/quickstart.md
@@ -8,10 +8,12 @@ it.
 
 Instructions available [here](https://docs.docker.com/engine/install/).
 
-2. Clone the repository:
+1. Clone the repository and checkout to the latest release (or a specific tag if you want). The
+   command below will get the latest tag without you needing to look it up:
 
 ```sh
 git clone https://github.com/weiss-controls/weiss.git
+git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 ```
 
 3. Configure your environment.

--- a/docs/src/production/env_variables.md
+++ b/docs/src/production/env_variables.md
@@ -14,11 +14,17 @@ cp .env.example .env
 These are injected at **build time** by Vite and baked into the static bundle. Changing them
 requires a rebuild.
 
-| Variable           | Default                                       | Description                                                                                                     |
-| ------------------ | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `GIT_REPO`         | `https://github.com/weiss-controls/weiss.git` | URL of the WEISS repository used for build (production build will always build from source!).                   |
-| `VITE_APP_VERSION` | `1.0.0`                                       | Application version checked out in build time and shown in the UI.                                              |
-| `VITE_DEMO_MODE`   | `true`                                        | When `true`, a demo (unauthenticated) login option is shown on the login page. Disable for private deployments. |
+| Variable         | Default | Description                                                                                                     |
+| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `VITE_DEMO_MODE` | `true`  | When `true`, a demo (unauthenticated) login option is shown on the login page. Disable for private deployments. |
+
+---
+
+## Docker image tagging
+
+| Variable     | Default  | Description                                                                               |
+| ------------ | -------- | ----------------------------------------------------------------------------------------- |
+| `DOCKER_TAG` | `latest` | Tag applied to all Docker images built by Compose (`weiss`, `weiss-api`, `weiss-epicsws`) |
 
 ---
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -64,7 +64,7 @@ export const FRONT_UI_ZIDX = parseInt(
 export const APP_SRC_URL = "https://github.com/weiss-controls/weiss";
 
 /** Running application version */
-export const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? "dev";
+export const APP_VERSION = __APP_VERSION__;
 
 /** WebSocket server URL for PV communication */
 export const WS_URL = (() => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,5 @@
 // Copyright (C) 2026 André Favoto
 
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import { execSync } from "child_process";
+
+function getVersion(): string {
+  return execSync("git describe --tags --always --dirty").toString().trim();
+}
+
+const version = getVersion();
 
 export default defineConfig({
   resolve: {
@@ -10,4 +17,7 @@ export default defineConfig({
     },
   },
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
 });


### PR DESCRIPTION
Derive the app version at build time, instead of requiring a `VITE_APP_VERSION` to be set externally. Variable is now called `__APP_VERSION__`. This simplifies the build UX since user only needs to checkout to the desired ref. 

This also allows build pipelines to work for fork repo contributions - it could never succeed since the tip of the PR branch was not part of the upstream contents - see #106 

Additional changes: add .dockerignore to avoid copying unnecessary content, update documentation accordingly.