### PR TITLE
feat: allow placing widget by clicking

### DIFF
--- a/src/components/GridZone/GridZoneComp.tsx
+++ b/src/components/GridZone/GridZoneComp.tsx
@@ -56,6 +56,9 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     deleteWidget,
     allWidgetIDs,
     pickedWidget,
+    setPickedWidget,
+    isPlacementMode,
+    setIsPlacementMode,
     groupSelected,
     ungroupSelected,
     moveSelected,
@@ -163,6 +166,7 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
 
     addWidget(newWidget);
     setDragPreview(null);
+    setPickedWidget(null);
   };
 
   const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
@@ -205,10 +209,30 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const handleClick = (_e: React.MouseEvent) => {
     setContextMenuVisible(false);
+    if (isPlacementMode && pickedWidget && !isPanning) {
+      const newWidget = createWidgetInstance(
+        pickedWidget,
+        `${pickedWidget.widgetName}-${uuidv4()}`,
+      );
+      if (newWidget.editableProperties.x)
+        newWidget.editableProperties.x.value = mousePosRef.current.x;
+      if (newWidget.editableProperties.y)
+        newWidget.editableProperties.y.value = mousePosRef.current.y;
+      addWidget(newWidget);
+      setPickedWidget(null);
+      setIsPlacementMode(false);
+      setDragPreview(null);
+    }
   };
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
+    if (isPlacementMode) {
+      setPickedWidget(null);
+      setIsPlacementMode(false);
+      setDragPreview(null);
+      return;
+    }
     setContextMenuPos({ x: e.clientX, y: e.clientY });
     setContextMenuVisible(true);
   };
@@ -226,6 +250,13 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
         x: ensureGridCoordinate(userX),
         y: ensureGridCoordinate(userY),
       };
+      if (isPlacementMode && pickedWidget) {
+        setDragPreview({
+          widget: pickedWidget,
+          x: ensureGridCoordinate(userX),
+          y: ensureGridCoordinate(userY),
+        });
+      }
       if (gridGrabbed.current) {
         const dx = e.clientX - lastPosRef.current.x;
         const dy = e.clientY - lastPosRef.current.y;
@@ -241,7 +272,18 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
     };
-  }, [gridGrabbed, isPanning, setIsPanning, ensureGridCoordinate, pan, zoom, mode]);
+  }, [
+    gridGrabbed,
+    isPanning,
+    setIsPanning,
+    ensureGridCoordinate,
+    pan,
+    zoom,
+    mode,
+    isPlacementMode,
+    pickedWidget,
+    setDragPreview,
+  ]);
 
   // Shortcuts handler
   useEffect(() => {
@@ -254,6 +296,13 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
       )
         return;
       // shortcuts for all modes
+      if (e.key === "Escape" && isPlacementMode) {
+        e.preventDefault();
+        setPickedWidget(null);
+        setIsPlacementMode(false);
+        setDragPreview(null);
+        return;
+      }
       if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "c") {
         e.preventDefault();
         centerScreen();
@@ -351,7 +400,7 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
       onMouseUp={handleMouseUp}
       onClick={handleClick}
       style={{
-        cursor: gridGrabbed.current ? "grabbing" : "default",
+        cursor: isPlacementMode ? "crosshair" : gridGrabbed.current ? "grabbing" : "default",
         backgroundColor: props.backgroundColor?.value,
         backgroundImage:
           gridLineVisible && inEditMode

--- a/src/components/WidgetPicker/WidgetPicker.tsx
+++ b/src/components/WidgetPicker/WidgetPicker.tsx
@@ -76,7 +76,9 @@ interface DraggableItemProps {
 }
 
 const DraggableItem: React.FC<DraggableItemProps> = ({ item, open }) => {
-  const { setPickedWidget } = useWidgetContext();
+  const { setPickedWidget, pickedWidget, isPlacementMode, setIsPlacementMode } = useWidgetContext();
+
+  const isActive = isPlacementMode && pickedWidget?.widgetName === item.widgetName;
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     e.dataTransfer.setData("application/json", JSON.stringify(item));
@@ -85,6 +87,18 @@ const DraggableItem: React.FC<DraggableItemProps> = ({ item, open }) => {
     img.src = "";
     e.dataTransfer.setDragImage(img, 0, 0);
     setPickedWidget(item);
+    setIsPlacementMode(false);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isActive) {
+      setPickedWidget(null);
+      setIsPlacementMode(false);
+    } else {
+      setPickedWidget(item);
+      setIsPlacementMode(true);
+    }
   };
 
   return (
@@ -92,7 +106,9 @@ const DraggableItem: React.FC<DraggableItemProps> = ({ item, open }) => {
       <Tooltip title={item.widgetLabel} placement="right">
         <ListItemButton
           draggable
+          selected={isActive}
           onDragStart={handleDragStart}
+          onClick={handleClick}
           sx={{ minHeight: 30, justifyContent: open ? "initial" : "center" }}
         >
           <ListItemIcon

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -47,6 +47,7 @@ export function useWidgetManager() {
     createWidgetInstance(GridZone, GRID_ID),
   ]);
   const [pickedWidget, setPickedWidget] = useState<WidgetDefinition | null>(null); // widget picked from palette
+  const [isPlacementMode, setIsPlacementMode] = useState(false);
   const [selectedWidgetIDs, setSelectedWidgetIDs] = useState<string[]>([]);
   const [fileLoadedTrig, setFileLoadedTrig] = useState(0);
 
@@ -862,5 +863,7 @@ export function useWidgetManager() {
     fileLoadedTrig,
     pickedWidget,
     setPickedWidget,
+    isPlacementMode,
+    setIsPlacementMode,
   };
 }


### PR DESCRIPTION
On top of drag and dropping from widget picker, users may want to select a widget by clicking on it in the selector, then clicking again on where they want to place it on the canvas (see [1]). Allow that by creating "PlacementMode". The same component preview was reused and is rendered on hover.

[1] - https://github.com/weiss-controls/weiss/issues/112