### PR TITLE
fix: attach epicsWS to host network

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -23,8 +23,7 @@ services:
       - ./backend/epicsWS:/app
     image: weiss-epicsws-dev:${DOCKER_TAG:-latest}
     container_name: weiss-epicsws-dev
-    ports:
-      - "8080:8080"
+    network_mode: host
     restart: always
     environment:
       EPICS_DEFAULT_PROTOCOL: ${EPICS_DEFAULT_PROTOCOL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     volumes:
       - ${SSL_CERT_FILE}:/etc/nginx/certs/fullchain.pem:ro
       - ${SSL_KEY_FILE}:/etc/nginx/certs/privkey.pem:ro
+    extra_hosts:
+      - "weiss-epicsws:host-gateway"
     depends_on:
       - weiss-epicsws
 
@@ -29,8 +31,7 @@ services:
       context: ./backend/epicsWS
     image: weiss-epicsws:${DOCKER_TAG:-latest}
     container_name: weiss-epicsws
-    ports:
-      - "8080:8080"
+    network_mode: host
     restart: always
     environment:
       EPICS_DEFAULT_PROTOCOL: ${EPICS_DEFAULT_PROTOCOL}

--- a/docs/src/getting_started/quickstart.md
+++ b/docs/src/getting_started/quickstart.md
@@ -24,8 +24,7 @@ First, create your `.env` file. You can start by just copying `.env.example` fro
 cp .env.example .env
 ```
 
-If you want to see PVs outside of localhost, adjust `DEFAULT_PROTOCOL` and `EPICS_XXX_ADDR_LIST`
-accordingly.
+If applicable, adjust `DEFAULT_PROTOCOL` and `EPICS_XXX_ADDR_LIST` accordingly.
 
 :::{important}  
 If running outside of your localhost, make sure to set `APP_HOSTNAME` to your server's IP address or

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weiss",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
fix: attach epicsWS to host network

This facilitates IOC communication, since all IOCs visible by the host
will now be visible by the epicsWS layer, regardless of port used,
unicast or broadcast schema applied.

minor update on docs and update pnpm package version