### PR TITLE
Fix build for newer pnpm and node versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,23 @@
 # Dev environment
-FROM node:20-alpine AS dev
+FROM node:22-alpine AS dev
 WORKDIR /app
 COPY . .
 # set /app as safe to allow git interaction on mounted folder
 RUN apk add --no-cache git \
  && git config --global --add safe.directory /app
-RUN npm install --global corepack@latest && corepack enable pnpm
+RUN npm install -g pnpm
 RUN pnpm install
 
 CMD pnpm run dev --host
 
 # Production build
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 ARG VITE_DEMO_MODE
 ENV VITE_DEMO_MODE=${VITE_DEMO_MODE}
 COPY . .
 RUN apk add --no-cache git
-RUN npm install --global corepack@latest && corepack enable pnpm
+RUN npm install -g pnpm
 RUN pnpm install && pnpm run build
 
 # Production image

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -3,7 +3,7 @@
 # The devcontainer should use the build target and run as root with podman
 # or docker with user namespaces.
 #
-FROM docker.io/library/python:3.14.4-slim-trixie as build
+FROM docker.io/library/python:3.14.4-slim-trixie AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -38,7 +38,7 @@ RUN pip install --upgrade pip && \
     # and replace with a comment to avoid a zero length asset upload later
     sed -i '/file:/s/^/# Requirements for /' lockfiles/requirements.txt
 
-FROM docker.io/library/python:3.14.4-slim-trixie as runtime
+FROM docker.io/library/python:3.14.4-slim-trixie AS runtime
 
 ARG APP_USER=weiss
 ARG APP_UID=1001

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  "@swc/core": true
+  es5-ext: true
+  esbuild: true


### PR DESCRIPTION
Changing to node 22 is necessary to use newer pnpm version. With that, a breaking change on pnpm API requires us to explicitly set the packages allowed to use scripts - now set on pnpm-workspace.

Additionally, fix FROM-AS case matching to get rid of warning on build time.