### PR TITLE
Feature: Widget tree

### DIFF
--- a/backend/api/src/api/repos/common.py
+++ b/backend/api/src/api/repos/common.py
@@ -19,7 +19,6 @@ REPO_META = "repo.json"
 OPI_EXTENSION = ".opi.json"
 NEW_FILE_CONTENT = [
     {
-        "id": "__grid__",
         "widgetName": "GridZone",
         "properties": {
             "backgroundColor": "#e9ecef",

--- a/src/components/EditorSidebar/EditorSidebar.tsx
+++ b/src/components/EditorSidebar/EditorSidebar.tsx
@@ -20,9 +20,11 @@ import PushPinIcon from "@mui/icons-material/PushPin";
 import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
 import ModeEditIcon from "@mui/icons-material/ModeEdit";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import { FRONT_UI_ZIDX } from "@src/constants/constants";
 import PropertyNavigator from "./PropertiesTab/PropertiesTab";
 import ProjectsTab from "./ProjectsTab/ProjectsTab";
+import WidgetTree from "@components/WidgetTree";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
@@ -64,7 +66,8 @@ const ResizeHandle = styled("div")({
 
 const EditorTab = {
   EDIT: 0,
-  NAVIGATE: 1,
+  LAYERS: 1,
+  NAVIGATE: 2,
 } as const;
 type EditorTab = (typeof EditorTab)[keyof typeof EditorTab];
 
@@ -97,7 +100,7 @@ const EditorSidebar: React.FC = () => {
 
   useEffect(() => {
     if (selectedWidgetIDs.length > 0) {
-      setTabIndex(EditorTab.EDIT);
+      setTabIndex((prev) => (prev === EditorTab.LAYERS ? EditorTab.LAYERS : EditorTab.EDIT));
       setOpen(true);
     } else if (!pinned) {
       setOpen(false);
@@ -153,11 +156,13 @@ const EditorSidebar: React.FC = () => {
   if (!inEditMode && !isAuthenticated) return null;
 
   const header =
-    tabIndex === 0
+    tabIndex === EditorTab.EDIT
       ? editingWidgets.length === 1
         ? `${WidgetRegistry[editingWidgets[0].widgetName]?.widgetLabel ?? editingWidgets[0].widgetName} properties`
         : "Common properties in selection"
-      : "Browse projects";
+      : tabIndex === EditorTab.LAYERS
+        ? "Widget layers"
+        : "Browse projects";
 
   return (
     <>
@@ -223,7 +228,13 @@ const EditorSidebar: React.FC = () => {
 
         {/* Content */}
         <div style={{ flex: "1 1 auto", overflowY: "auto" }}>
-          {tabIndex === 0 ? <PropertyNavigator /> : <ProjectsTab />}
+          {tabIndex === EditorTab.EDIT ? (
+            <PropertyNavigator />
+          ) : tabIndex === EditorTab.LAYERS ? (
+            <WidgetTree />
+          ) : (
+            <ProjectsTab />
+          )}
         </div>
 
         {/* Tabs */}
@@ -244,7 +255,18 @@ const EditorSidebar: React.FC = () => {
               label="Edit"
               sx={{
                 textTransform: "none",
-                width: "50%",
+                width: "33%",
+                minHeight: 0,
+                paddingTop: 1.5,
+              }}
+            />
+            <Tab
+              icon={<AccountTreeIcon fontSize="small" />}
+              iconPosition="start"
+              label="Layers"
+              sx={{
+                textTransform: "none",
+                width: "33%",
                 minHeight: 0,
                 paddingTop: 1.5,
               }}
@@ -255,7 +277,7 @@ const EditorSidebar: React.FC = () => {
               label="Navigate"
               sx={{
                 textTransform: "none",
-                width: "50%",
+                width: "34%",
                 minHeight: 0,
                 paddingTop: 1.5,
               }}

--- a/src/components/WidgetTree/WidgetTree.tsx
+++ b/src/components/WidgetTree/WidgetTree.tsx
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import { useMemo, useState, useCallback } from "react";
+import { RichTreeView } from "@mui/x-tree-view/RichTreeView";
+import { useWidgetContext } from "@src/context/useWidgetContext";
+import { GRID_ID } from "@src/constants/constants";
+import type { Widget } from "@src/types/widgets";
+import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
+import WidgetTreeItem, {
+  DndProvider,
+  type WidgetLayerItem,
+  type WidgetTreeDndCtx,
+} from "./WidgetTreeItem";
+
+function buildLayerItems(widgets: Widget[], groupId: string | null): WidgetLayerItem[] {
+  return widgets.map((w) => ({
+    id: w.id,
+    itemId: w.id,
+    label: WidgetRegistry[w.widgetName]?.widgetLabel ?? w.widgetName,
+    widgetName: w.widgetName,
+    groupId,
+    children:
+      w.children && w.children.length > 0 && w.widgetName !== "EmbeddedDisplay"
+        ? buildLayerItems(w.children, w.id)
+        : undefined,
+  }));
+}
+
+function reorderList<T extends { id: string }>(
+  list: T[],
+  draggedId: string,
+  targetId: string,
+  position: "before" | "after",
+): T[] {
+  const result = list.filter((item) => item.id !== draggedId);
+  const dragged = list.find((item) => item.id === draggedId);
+  if (!dragged) return list;
+  const targetIdx = result.findIndex((item) => item.id === targetId);
+  if (targetIdx === -1) return list;
+  const insertAt = position === "before" ? targetIdx : targetIdx + 1;
+  result.splice(insertAt, 0, dragged);
+  return result;
+}
+
+const WidgetTree: React.FC = () => {
+  const {
+    editorWidgets,
+    selectedWidgetIDs,
+    setSelectedWidgetIDs,
+    updateEditorWidgetList,
+    updateWidgetChildren,
+    getWidget,
+  } = useWidgetContext();
+
+  // build tree items (render front-first, reversed from editorWidgets)
+  const topLevelWidgets = useMemo(
+    () => editorWidgets.filter((w) => w.id !== GRID_ID),
+    [editorWidgets],
+  );
+
+  const treeItems = useMemo<WidgetLayerItem[]>(
+    () => buildLayerItems([...topLevelWidgets].reverse(), null),
+    [topLevelWidgets],
+  );
+
+  const defaultExpandedIds = useMemo(
+    () => topLevelWidgets.filter((w) => w.children?.length).map((w) => w.id),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [], // only compute once on mount — RichTreeView manages expand state internally
+  );
+
+  // drag-and-drop state
+  const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
+  const [draggedGroupId, setDraggedGroupId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{
+    id: string;
+    position: "before" | "after";
+  } | null>(null);
+
+  const handleDragStart = useCallback((id: string, groupId: string | null) => {
+    setDraggedItemId(id);
+    setDraggedGroupId(groupId);
+    setDropTarget(null);
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedItemId(null);
+    setDraggedGroupId(null);
+    setDropTarget(null);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (id: string, position: "before" | "after", targetGroupId: string | null) => {
+      if (!draggedItemId || id === draggedItemId) return;
+      // Reject cross-scope drops
+      if (draggedGroupId !== targetGroupId) return;
+      setDropTarget({ id, position });
+    },
+    [draggedItemId, draggedGroupId],
+  );
+
+  const handleDrop = useCallback(
+    (targetId: string, position: "before" | "after", targetGroupId: string | null) => {
+      if (!draggedItemId || draggedItemId === targetId) {
+        handleDragEnd();
+        return;
+      }
+      // Reject cross-scope drops
+      if (draggedGroupId !== targetGroupId) {
+        handleDragEnd();
+        return;
+      }
+
+      if (draggedGroupId === null) {
+        // Reorder in display order, then reverse back to storage order and
+        // prepend the grid widget.
+        const displayOrder = reorderList(
+          [...topLevelWidgets].reverse(),
+          draggedItemId,
+          targetId,
+          position,
+        );
+        const grid = editorWidgets.find((w) => w.id === GRID_ID)!;
+        updateEditorWidgetList([grid, ...displayOrder.reverse()]);
+      } else {
+        // group children reorder
+        const parent = getWidget(draggedGroupId);
+        if (!parent?.children) {
+          handleDragEnd();
+          return;
+        }
+        const reordered = reorderList(parent.children, draggedItemId, targetId, position);
+        updateWidgetChildren(draggedGroupId, reordered);
+      }
+
+      handleDragEnd();
+    },
+    [
+      draggedItemId,
+      draggedGroupId,
+      topLevelWidgets,
+      editorWidgets,
+      updateEditorWidgetList,
+      updateWidgetChildren,
+      getWidget,
+      handleDragEnd,
+    ],
+  );
+
+  const dndCtx: WidgetTreeDndCtx = {
+    draggedItemId,
+    draggedGroupId,
+    dropTarget,
+    onDragStart: handleDragStart,
+    onDragEnd: handleDragEnd,
+    onDragOver: handleDragOver,
+    onDrop: handleDrop,
+  };
+
+  const handleSelectionChange = useCallback(
+    (_e: React.SyntheticEvent | null, ids: string[]) => {
+      setSelectedWidgetIDs(ids);
+    },
+    [setSelectedWidgetIDs],
+  );
+
+  return (
+    <DndProvider value={dndCtx}>
+      <RichTreeView
+        items={treeItems}
+        selectedItems={selectedWidgetIDs}
+        onSelectedItemsChange={handleSelectionChange}
+        multiSelect
+        isItemEditable={() => false}
+        defaultExpandedItems={defaultExpandedIds}
+        slots={{ item: WidgetTreeItem }}
+        sx={{ p: 1 }}
+      />
+    </DndProvider>
+  );
+};
+
+export default WidgetTree;

--- a/src/components/WidgetTree/WidgetTree.tsx
+++ b/src/components/WidgetTree/WidgetTree.tsx
@@ -13,11 +13,17 @@ import WidgetTreeItem, {
   type WidgetTreeDndCtx,
 } from "./WidgetTreeItem";
 
+function widgetTreeLabel(w: Widget): string {
+  const alias = w.editableProperties.alias?.value;
+  if (alias) return alias;
+  return WidgetRegistry[w.widgetName]?.widgetLabel ?? w.widgetName;
+}
+
 function buildLayerItems(widgets: Widget[], groupId: string | null): WidgetLayerItem[] {
   return widgets.map((w) => ({
     id: w.id,
     itemId: w.id,
-    label: WidgetRegistry[w.widgetName]?.widgetLabel ?? w.widgetName,
+    label: widgetTreeLabel(w),
     widgetName: w.widgetName,
     groupId,
     children:
@@ -50,6 +56,7 @@ const WidgetTree: React.FC = () => {
     setSelectedWidgetIDs,
     updateEditorWidgetList,
     updateWidgetChildren,
+    updateWidgetProperties,
     getWidget,
   } = useWidgetContext();
 
@@ -172,7 +179,10 @@ const WidgetTree: React.FC = () => {
         selectedItems={selectedWidgetIDs}
         onSelectedItemsChange={handleSelectionChange}
         multiSelect
-        isItemEditable={() => false}
+        isItemEditable={(item) => item.id !== GRID_ID}
+        onItemLabelChange={(itemId, newLabel) =>
+          updateWidgetProperties(itemId, { alias: newLabel })
+        }
         defaultExpandedItems={defaultExpandedIds}
         slots={{ item: WidgetTreeItem }}
         sx={{ p: 1 }}

--- a/src/components/WidgetTree/WidgetTreeItem.tsx
+++ b/src/components/WidgetTree/WidgetTreeItem.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import { createContext, useContext, forwardRef } from "react";
+import { Collapse } from "@mui/material";
+import {
+  type TreeViewDefaultItemModelProperties,
+  TreeItemLabel,
+  TreeItemIcon,
+  TreeItemLabelInput,
+} from "@mui/x-tree-view";
+import { useTreeItem, type UseTreeItemParameters } from "@mui/x-tree-view/useTreeItem";
+import { TreeItemRoot, TreeItemContent, TreeItemIconContainer } from "@mui/x-tree-view/TreeItem";
+import { TreeItemProvider } from "@mui/x-tree-view/TreeItemProvider";
+import { useTreeItemModel, useTreeItemUtils } from "@mui/x-tree-view/hooks";
+import WidgetsIcon from "@mui/icons-material/Widgets";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
+import { COLORS } from "@src/constants/constants";
+
+export type WidgetLayerItem = TreeViewDefaultItemModelProperties & {
+  widgetName: string;
+  /** null = top-level widget, string = parent group/embedded-display id */
+  groupId: string | null;
+  children?: WidgetLayerItem[];
+};
+
+export interface WidgetTreeDndCtx {
+  draggedItemId: string | null;
+  draggedGroupId: string | null;
+  dropTarget: { id: string; position: "before" | "after" } | null;
+  onDragStart: (id: string, groupId: string | null) => void;
+  onDragEnd: () => void;
+  onDragOver: (id: string, position: "before" | "after", groupId: string | null) => void;
+  onDrop: (targetId: string, position: "before" | "after", targetGroupId: string | null) => void;
+}
+
+const DndContext = createContext<WidgetTreeDndCtx | null>(null);
+
+export function DndProvider({
+  value,
+  children,
+}: {
+  value: WidgetTreeDndCtx;
+  children: React.ReactNode;
+}) {
+  return <DndContext.Provider value={value}>{children}</DndContext.Provider>;
+}
+
+const WidgetTreeItem = forwardRef<HTMLLIElement, UseTreeItemParameters>(
+  function WidgetTreeItem(props, ref) {
+    const { id, itemId, label, disabled, children, ...other } = props;
+
+    const {
+      getContextProviderProps,
+      getRootProps,
+      getContentProps,
+      getIconContainerProps,
+      getLabelProps,
+      getLabelInputProps,
+      getGroupTransitionProps,
+      status,
+    } = useTreeItem({ id, itemId, children, label, disabled, rootRef: ref });
+
+    const { interactions } = useTreeItemUtils({ itemId, children });
+    const dndCtx = useContext(DndContext);
+    const item = useTreeItemModel<WidgetLayerItem>(itemId)!;
+
+    const def = WidgetRegistry[item.widgetName];
+    const WIcon = def?.widgetIcon;
+    const iconSx = { color: COLORS.midGray, fontSize: 16 };
+
+    const isDragging = dndCtx?.draggedItemId === itemId;
+    const dropPos = dndCtx?.dropTarget?.id === itemId ? dndCtx.dropTarget.position : null;
+
+    const dragHandlers: React.HTMLAttributes<HTMLElement> = {
+      draggable: true,
+      onDragStart: (e) => {
+        e.stopPropagation();
+        e.dataTransfer.effectAllowed = "move";
+        dndCtx?.onDragStart(itemId, item.groupId);
+      },
+      onDragEnd: () => dndCtx?.onDragEnd(),
+      onDragOver: (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        e.dataTransfer.dropEffect = "move";
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const position = e.clientY < rect.top + rect.height / 2 ? "before" : "after";
+        dndCtx?.onDragOver(itemId, position, item.groupId);
+      },
+      onDragLeave: (e) => {
+        e.stopPropagation();
+        // Only clear if leaving to outside this element
+        const ct = e.currentTarget as HTMLElement;
+        const rt = e.relatedTarget as Node | null;
+        if (!rt || !ct.contains(rt)) {
+          dndCtx?.onDragOver(itemId, "after", item.groupId); // reset by re-evaluating on next enter
+        }
+      },
+      onDrop: (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!dndCtx) return;
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const position = e.clientY < rect.top + rect.height / 2 ? "before" : "after";
+        dndCtx.onDrop(itemId, position, item.groupId);
+      },
+    };
+
+    const handleInputChange = getLabelInputProps({
+      onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
+        (event as unknown as { defaultMuiPrevented: boolean }).defaultMuiPrevented = true;
+        const target = event.target as HTMLInputElement;
+        if (event.key === "Enter") {
+          if (target.value.trim()) {
+            interactions.handleSaveItemLabel(event, target.value);
+          }
+        } else if (event.key === "Escape") {
+          interactions.handleCancelItemLabelEditing(event);
+        }
+      },
+    });
+
+    return (
+      <TreeItemProvider {...getContextProviderProps()}>
+        <TreeItemRoot {...getRootProps(other)}>
+          <TreeItemContent
+            {...getContentProps()}
+            {...dragHandlers}
+            style={{
+              opacity: isDragging ? 0.4 : 1,
+              borderTop: dropPos === "before" ? `2px solid ${COLORS.highlighted}` : undefined,
+              borderBottom: dropPos === "after" ? `2px solid ${COLORS.highlighted}` : undefined,
+            }}
+          >
+            <DragIndicatorIcon sx={{ opacity: "0.4" }} />
+            <TreeItemIconContainer {...getIconContainerProps()}>
+              <TreeItemIcon status={status} />
+            </TreeItemIconContainer>
+            {WIcon ? <WIcon sx={iconSx} /> : <WidgetsIcon sx={iconSx} />}
+            {status.editing ? (
+              <TreeItemLabelInput {...handleInputChange} />
+            ) : (
+              <TreeItemLabel {...getLabelProps()} sx={{ fontWeight: 300, fontSize: "0.85rem" }} />
+            )}
+          </TreeItemContent>
+          {children && (
+            <Collapse {...getGroupTransitionProps()} sx={{ pl: 1 }}>
+              {children}
+            </Collapse>
+          )}
+        </TreeItemRoot>
+      </TreeItemProvider>
+    );
+  },
+);
+
+export default WidgetTreeItem;

--- a/src/components/WidgetTree/index.ts
+++ b/src/components/WidgetTree/index.ts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+export { default } from "./WidgetTree";

--- a/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplay.ts
+++ b/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplay.ts
@@ -13,11 +13,12 @@ export const EmbeddedDisplay: WidgetDefinition = {
   widgetLabel: "Embedded Display",
   category: "Basic",
   defaultProperties: {
+    alias: PROPERTY_SCHEMAS.alias,
     x: PROPERTY_SCHEMAS.x,
     y: PROPERTY_SCHEMAS.y,
-    tooltip: PROPERTY_SCHEMAS.tooltip,
     width: { ...PROPERTY_SCHEMAS.width, value: 300 },
     height: { ...PROPERTY_SCHEMAS.height, value: 210 },
+    tooltip: PROPERTY_SCHEMAS.tooltip,
     displayPath: PROPERTY_SCHEMAS.displayPath,
     macros: PROPERTY_SCHEMAS.macros,
   },

--- a/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplayComp.tsx
+++ b/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplayComp.tsx
@@ -10,7 +10,6 @@ import { getDeployedRepoFile, getStagingRepoFile } from "@src/services/APIClient
 import { resolveRepoPath } from "@src/utils/repoPath";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import { createGroupWidget } from "@src/context/widgetHelpers";
-import { GRID_ID } from "@src/constants/constants";
 import type { PropertyKey } from "@src/types/widgets";
 
 /**
@@ -27,13 +26,13 @@ const _contentCache = new Map<string, Promise<ExportedWidget[]>>();
  * Any widget whose type is unrecognised is silently dropped.
  */
 function exportedToWidget(raw: ExportedWidget): Widget | null {
-  if (raw.widgetName === "GridZone" || raw.id === GRID_ID) return null;
+  if (raw.widgetName === "GridZone") return null;
 
   const children = raw.children?.map(exportedToWidget).filter((w): w is Widget => w !== null);
 
   // groups are not in the registry
   if (raw.widgetName === "Group") {
-    const group = createGroupWidget(raw.id, children ?? []);
+    const group = createGroupWidget(uuidv4(), children ?? []);
     // Overlay the serialised x/y/width/height onto the group.
     for (const key of ["x", "y", "width", "height"] as const) {
       if (raw.properties?.[key] !== undefined && group.editableProperties[key]) {
@@ -54,7 +53,7 @@ function exportedToWidget(raw: ExportedWidget): Widget | null {
   );
 
   return {
-    id: raw.id,
+    id: `${raw.widgetName}-${uuidv4()}`,
     widgetName: raw.widgetName,
     editableProperties,
     children,
@@ -76,7 +75,7 @@ function computeNatBounds(exported: ExportedWidget[]): {
   let maxY = -Infinity;
 
   for (const w of exported) {
-    if (w.widgetName === "GridZone" || w.id === GRID_ID) continue;
+    if (w.widgetName === "GridZone") continue;
     const x = (w.properties?.x as number | undefined) ?? 0;
     const y = (w.properties?.y as number | undefined) ?? 0;
     const width = (w.properties?.width as number | undefined) ?? 0;

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -162,11 +162,27 @@ export function useWidgetManager() {
 
   /**
    * Add a new widget to the editor.
+   * Auto-assigns an alias of the form "{widgetLabel} {n}" when the widget has a
+   * name property that is currently empty (new drops/placements).
    * @param newWidget Widget to add
    */
   const addWidget = useCallback(
     (newWidget: Widget) => {
-      updateEditorWidgetList((prev) => [...prev, newWidget]);
+      updateEditorWidgetList((prev) => {
+        let widget = newWidget;
+        if (widget.editableProperties.alias?.value === "") {
+          const count = prev.filter((w) => w.widgetName === widget.widgetName).length;
+          const label = WidgetRegistry[widget.widgetName]?.widgetLabel ?? widget.widgetName;
+          widget = {
+            ...widget,
+            editableProperties: {
+              ...widget.editableProperties,
+              alias: { ...widget.editableProperties.alias, value: `${label} ${count + 1}` },
+            },
+          };
+        }
+        return [...prev, widget];
+      });
     },
     [updateEditorWidgetList],
   );

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -635,7 +635,6 @@ export function useWidgetManager() {
         ? undefined
         : widget.children?.map((child) => formatWdgToExport(child));
     return {
-      id: widget.id,
       widgetName: widget.widgetName,
       properties: Object.fromEntries(
         Object.entries(widget.editableProperties).map(([key, def]) => [key, def.value]),
@@ -718,17 +717,17 @@ export function useWidgetManager() {
 
           const isGroup = raw.widgetName === "Group";
 
-          if (idx === 0 && raw.id === GRID_ID) {
+          if (idx === 0 && raw.widgetName === "GridZone") {
             instance = createWidgetInstance(GridZone, GRID_ID);
           } else if (isGroup) {
-            instance = createGroupWidget(raw.id);
+            instance = createGroupWidget(uuidv4());
           } else {
             const baseWdg = WidgetRegistry[raw.widgetName];
             if (!baseWdg) {
-              warnings.push(`Unknown widget type "${raw.widgetName}" (id: ${raw.id}) — skipped`);
+              warnings.push(`Unknown widget type "${raw.widgetName}" — skipped`);
               return null;
             }
-            instance = createWidgetInstance(baseWdg, raw.id);
+            instance = createWidgetInstance(baseWdg, `${raw.widgetName}-${uuidv4()}`);
           }
 
           // Recursively restore children
@@ -744,9 +743,7 @@ export function useWidgetManager() {
             if (instance.editableProperties[propName]) {
               instance.editableProperties[propName].value = val;
             } else {
-              warnings.push(
-                `Unknown property "${key}" on widget "${raw.widgetName}" (id: ${raw.id}) — ignored`,
-              );
+              warnings.push(`Unknown property "${key}" on widget "${raw.widgetName}" — ignored`);
             }
           }
           return instance;

--- a/src/types/widgetProperties.ts
+++ b/src/types/widgetProperties.ts
@@ -23,6 +23,7 @@ export const PROPERTY_SCHEMAS = {
   disabled:        defineProp({ selType: "boolean", label: "Disabled", value: false as boolean, category: "General" }),
   macros:          defineProp({ selType: "strRecord", label: "Macro", value: {} as Record<string, string>, category: "EPICS" }),
   // Layout
+  alias:           defineProp({ selType: "text", label: "Widget alias", value: "" as string, category: "Layout" }),
   x:               defineProp({ selType: "number", label: "X", value: 100 as number, category: "Layout" }),
   y:               defineProp({ selType: "number", label: "Y", value: 100 as number, category: "Layout" }),
   width:           defineProp({ selType: "number", label: "Width", value: 100 as number, limits: { min: 1 }, category: "Layout" }),
@@ -120,6 +121,7 @@ export const CATEGORY_DISPLAY_ORDER = [
  * Common set of widget properties shared across most widgets.
  */
 export const COMMON_PROPS: WidgetProperties = {
+  alias: PROPERTY_SCHEMAS.alias,
   x: PROPERTY_SCHEMAS.x,
   y: PROPERTY_SCHEMAS.y,
   width: PROPERTY_SCHEMAS.width,

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -138,12 +138,10 @@ export interface Widget {
 
 /**
  * Simplified representation of a widget for export.
- * @property id Widget ID
  * @property widgetName Widget name
  * @property properties Partial properties of the widget
  */
 export interface ExportedWidget {
-  id: string;
   children?: ExportedWidget[];
   widgetName: string;
   properties: Partial<Record<PropertyKey, PropertyValue>>;


### PR DESCRIPTION
- Add a new navigation tab for the widget tree. 
This allows users to see which items are placed in the current screen, reorder their positions, and rename their aliases (via double click).

- A new widget property was created: "Widget alias". 
It works as a generic name to refer to the widget in the tree. It is not, however, an ID, which means it can be repeated.

- Remove "id" from exported content.
It should have never been there in the first place - users do not need to have access to it, and it is a runtime concern only. 