### PR TITLE
Feature: extended macro replacement, internal macros

### DIFF
--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -11,7 +11,7 @@ import type { PVData } from "@src/types/epicsWS";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { useEpicsWSContext } from "@src/context/useEpicsWSContext";
-import { substituteInStr, substituteTextProps } from "@src/utils/macros";
+import { buildInternalMacros, substituteInStr, substituteTextProps } from "@src/utils/macros";
 
 const DRAG_END_DELAY = 80; //ms
 
@@ -99,9 +99,15 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
       }
 
       const merged: Widget = { ...w, pvData, multiPvData, children: newChildren };
+      const internalMacros = buildInternalMacros(
+        pvName ? substituteInStr(pvName, gridMacros) : undefined,
+        pvData,
+      );
+      const allMacros =
+        Object.keys(internalMacros).length > 0 ? { ...gridMacros, ...internalMacros } : gridMacros;
       const mergedWithMacros: Widget = {
         ...merged,
-        editableProperties: substituteTextProps(merged.editableProperties, gridMacros),
+        editableProperties: substituteTextProps(merged.editableProperties, allMacros),
       };
       nextWidgetsMap.set(w.id, mergedWithMacros);
       return mergedWithMacros;

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -11,6 +11,7 @@ import type { PVData } from "@src/types/epicsWS";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { useEpicsWSContext } from "@src/context/useEpicsWSContext";
+import { substituteInStr, substituteTextProps } from "@src/utils/macros";
 
 const DRAG_END_DELAY = 80; //ms
 
@@ -37,10 +38,18 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
   // Refs to track previous pvState entries and previously computed Widget objects.
   const prevPVStateRef = useRef<Record<string, PVData>>({});
   const prevWidgetsMapRef = useRef<Map<string, Widget>>(new Map());
+  const prevInEditModeRef = useRef(inEditMode);
 
   const widgetsForRender = useMemo(() => {
+    const gridMacros =
+      editorWidgets.find((w) => w.id === GRID_ID)?.editableProperties.macros?.value ?? {};
     const prevPVState = prevPVStateRef.current;
-    const prevWidgetsMap = prevWidgetsMapRef.current;
+    // On mode switch, discard the cache so every widget is fully recomputed for the new mode.
+    // Without this, widgets with no PV would pass the stability check and skip macro substitution
+    // (or, going the other way, keep stale substituted text in edit mode).
+    const modeChanged = inEditMode !== prevInEditModeRef.current;
+    prevInEditModeRef.current = inEditMode;
+    const prevWidgetsMap = modeChanged ? new Map<string, Widget>() : prevWidgetsMapRef.current;
     const nextWidgetsMap = new Map<string, Widget>();
 
     const mergeWidget = (w: Widget): Widget => {
@@ -84,13 +93,18 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
         multiPvData = {};
         for (const pv of pvNames) {
           const d = pvState[pv];
-          if (d) multiPvData[pv] = d;
+          // Key by substituted name so it matches pvNames.value after substituteTextProps
+          if (d) multiPvData[substituteInStr(pv, gridMacros)] = d;
         }
       }
 
       const merged: Widget = { ...w, pvData, multiPvData, children: newChildren };
-      nextWidgetsMap.set(w.id, merged);
-      return merged;
+      const mergedWithMacros: Widget = {
+        ...merged,
+        editableProperties: substituteTextProps(merged.editableProperties, gridMacros),
+      };
+      nextWidgetsMap.set(w.id, mergedWithMacros);
+      return mergedWithMacros;
     };
 
     const result = editorWidgets.map(mergeWidget);

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -238,7 +238,7 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
         size={{ width, height }}
         position={{ x, y }}
         className={editModeClass}
-        style={isEmbedded ? { pointerEvents: "none" } : undefined}
+        style={isEmbedded && inEditMode ? { pointerEvents: "none" } : undefined}
         onDrag={() => setIsDragging(true)}
         onDragStop={(e, d) => handleDragStop(e, d, w)}
         onResizeStart={() => setIsDragging(true)}

--- a/src/components/Widgets/Ellipse/Ellipse.ts
+++ b/src/components/Widgets/Ellipse/Ellipse.ts
@@ -20,5 +20,6 @@ export const Ellipse: WidgetDefinition = {
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.lightGray },
     width: { ...PROPERTY_SCHEMAS.width, value: 80 },
     height: { ...PROPERTY_SCHEMAS.height, value: 80 },
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
   },
 };

--- a/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplay.ts
+++ b/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplay.ts
@@ -18,7 +18,7 @@ export const EmbeddedDisplay: WidgetDefinition = {
     y: PROPERTY_SCHEMAS.y,
     width: { ...PROPERTY_SCHEMAS.width, value: 300 },
     height: { ...PROPERTY_SCHEMAS.height, value: 210 },
-    tooltip: PROPERTY_SCHEMAS.tooltip,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
     displayPath: PROPERTY_SCHEMAS.displayPath,
     macros: PROPERTY_SCHEMAS.macros,
   },

--- a/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplayComp.tsx
+++ b/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplayComp.tsx
@@ -8,6 +8,7 @@ import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { getDeployedRepoFile, getStagingRepoFile } from "@src/services/APIClient";
 import { resolveRepoPath } from "@src/utils/repoPath";
+import { substituteInStr, substituteTextProps } from "@src/utils/macros";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import { createGroupWidget } from "@src/context/widgetHelpers";
 import type { PropertyKey } from "@src/types/widgets";
@@ -116,25 +117,27 @@ function offsetWidgets(
   });
 }
 
-/** Substitute $(MACRO) patterns in a single string using a macros map. */
-function substituteInStr(str: string, macros: Record<string, string>): string {
-  return str.replace(/\$\(([^)]+)\)/g, (match) => macros[match] ?? match);
-}
-
 /**
- * Walk the widget tree and replace macros in pvName / pvNames.
+ * Walk the widget tree and replace macros in pvName, pvNames, and all text
+ * selType properties (labels, tooltips, titles, etc.).
  */
 function applyMacros(widgets: Widget[], macros: Record<string, string>): Widget[] {
   if (Object.keys(macros).length === 0) return widgets;
   return widgets.map((w) => {
-    const props = { ...w.editableProperties };
+    let props = substituteTextProps(w.editableProperties, macros);
     if (props.pvName?.value) {
-      props.pvName = { ...props.pvName, value: substituteInStr(props.pvName.value, macros) };
+      props = {
+        ...props,
+        pvName: { ...props.pvName, value: substituteInStr(props.pvName.value, macros) },
+      };
     }
     if (props.pvNames?.value && props.pvNames.value.length > 0) {
-      props.pvNames = {
-        ...props.pvNames,
-        value: props.pvNames.value.map((pv) => substituteInStr(pv, macros)),
+      props = {
+        ...props,
+        pvNames: {
+          ...props.pvNames,
+          value: props.pvNames.value.map((pv) => substituteInStr(pv, macros)),
+        },
       };
     }
     return {

--- a/src/components/Widgets/GraphY/GraphY.tsx
+++ b/src/components/Widgets/GraphY/GraphY.tsx
@@ -19,6 +19,7 @@ export const GraphY: WidgetDefinition = {
   category: "Monitoring",
   defaultProperties: {
     ...COMMON_PROPS,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
     width: { ...PROPERTY_SCHEMAS.width, value: 480 },
     height: { ...PROPERTY_SCHEMAS.height, value: 260 },
     ...PLOT_PROPS,

--- a/src/components/Widgets/Image/Image.ts
+++ b/src/components/Widgets/Image/Image.ts
@@ -16,6 +16,7 @@ export const Image: WidgetDefinition = {
   category: "Basic",
   defaultProperties: {
     ...FILTERED_COMMON_PROPS,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
     width: { ...PROPERTY_SCHEMAS.width, value: 120 },
     height: { ...PROPERTY_SCHEMAS.height, value: 120 },
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: "transparent" },

--- a/src/components/Widgets/NavigationButton/NavigationButton.ts
+++ b/src/components/Widgets/NavigationButton/NavigationButton.ts
@@ -21,5 +21,6 @@ export const NavigationButton: WidgetDefinition = {
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.buttonColor },
     displayPath: PROPERTY_SCHEMAS.displayPath,
     disabled: PROPERTY_SCHEMAS.disabled,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
   },
 };

--- a/src/components/Widgets/Rectangle/Rectangle.ts
+++ b/src/components/Widgets/Rectangle/Rectangle.ts
@@ -17,6 +17,7 @@ export const Rectangle: WidgetDefinition = {
   category: "Basic",
   defaultProperties: {
     ...FILTERED_COMMON_PROPS,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
     width: { ...PROPERTY_SCHEMAS.width, value: 80 },
     height: { ...PROPERTY_SCHEMAS.height, value: 80 },
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.lightGray },

--- a/src/components/Widgets/TextLabel/TextLabel.ts
+++ b/src/components/Widgets/TextLabel/TextLabel.ts
@@ -19,5 +19,6 @@ export const TextLabel: WidgetDefinition = {
     ...COMMON_WO_ALARMS,
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: "transparent" },
     ...TEXT_PROPS,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
   },
 };

--- a/src/context/useEpicsWS.ts
+++ b/src/context/useEpicsWS.ts
@@ -155,17 +155,9 @@ export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["P
    * @param pv The pv to be written to (with macros if applicable)
    * @param newValue New value [@type PVValue]
    */
-  const writePVValue = useCallback(
-    (pv: string, newValue: PVValue) => {
-      const substituted = PVMap.get(pv);
-      if (substituted) {
-        ws.current?.write(substituted, newValue);
-      } else {
-        console.warn(`writePVValue: unknown PV ${pv}`);
-      }
-    },
-    [PVMap],
-  );
+  const writePVValue = useCallback((pv: string, newValue: PVValue) => {
+    ws.current?.write(pv, newValue);
+  }, []);
 
   return {
     ws,

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -17,6 +17,7 @@ import { GRID_ID, MAX_HISTORY } from "@src/constants/constants";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import { v4 as uuidv4 } from "uuid";
 import { notifyUser } from "@src/services/Notifications/Notification";
+import { substituteInStr } from "@src/utils/macros";
 import {
   createGroupWidget,
   createWidgetInstance,
@@ -783,13 +784,7 @@ export function useWidgetManager() {
    * If a macro key is not found in macros, the original macro text is kept.
    */
   const substituteMacros = useCallback(
-    (pv: string): string => {
-      return pv.replace(/\$\(([^)]+)\)/g, (macro) => {
-        if (!macros) return macro;
-        const replacement = macros[macro];
-        return replacement ?? macro;
-      });
-    },
+    (pv: string): string => (macros ? substituteInStr(pv, macros) : pv),
     [macros],
   );
 

--- a/src/types/widgetProperties.ts
+++ b/src/types/widgetProperties.ts
@@ -29,7 +29,7 @@ export const PROPERTY_SCHEMAS = {
   width:           defineProp({ selType: "number", label: "Width", value: 100 as number, limits: { min: 1 }, category: "Layout" }),
   height:          defineProp({ selType: "number", label: "Height", value: 40 as number, limits: { min: 1 }, category: "Layout" }),
   label:           defineProp({ selType: "text", label: "Label", value: "" as string, category: "Text" }),
-  tooltip:         defineProp({ selType: "text", label: "Tooltip", value: "" as string, category: "Text" }),
+  tooltip:         defineProp({ selType: "text", label: "Tooltip", value: "$(pvname) - $(pvdesc)" as string, category: "Text" }),
   visible:         defineProp({ selType: "none", label: "Visible", value: true as boolean, category: "Layout" }),
   // Style
   backgroundColor: defineProp({ selType: "colorSel", label: "Background Color", value: COLORS.backgroundColor, category: "Style" }),

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import type { PropertyKey, WidgetProperties, WidgetProperty } from "@src/types/widgets";
+
+/**
+ * Substitute $(MACRO_NAME) patterns in a single string using a macros map.
+ * Unresolved macros (no matching key) are left as-is.
+ */
+export function substituteInStr(str: string, macros: Record<string, string>): string {
+  return str.replace(/\$\(([^)]+)\)/g, (match) => macros[match] ?? match);
+}
+
+/**
+ * Return a copy of the given properties with macros substituted in every
+ * property whose selType is "text".  All other properties are returned
+ * unchanged (same object references).
+ */
+export function substituteTextProps(
+  props: WidgetProperties,
+  macros: Record<string, string>,
+): WidgetProperties {
+  if (Object.keys(macros).length === 0) return props;
+
+  const result: WidgetProperties = {};
+  const resultRecord = result as Record<PropertyKey, WidgetProperty>;
+  for (const key of Object.keys(props) as PropertyKey[]) {
+    const prop = props[key];
+    if (!prop) {
+      continue;
+    }
+    if (prop.selType === "text" && typeof prop.value === "string") {
+      const substituted = substituteInStr(prop.value, macros);
+      resultRecord[key] = substituted !== prop.value ? { ...prop, value: substituted } : prop;
+    } else if (prop.selType === "strList" && Array.isArray(prop.value)) {
+      const original = prop.value as string[];
+      const substituted = original.map((s) => substituteInStr(s, macros));
+      resultRecord[key] = substituted.some((s, i) => s !== original[i])
+        ? { ...prop, value: substituted }
+        : prop;
+    } else {
+      resultRecord[key] = prop;
+    }
+  }
+  return result;
+}

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
+import type { PVData } from "@src/types/epicsWS";
 import type { PropertyKey, WidgetProperties, WidgetProperty } from "@src/types/widgets";
 
 /**
@@ -9,6 +10,29 @@ import type { PropertyKey, WidgetProperties, WidgetProperty } from "@src/types/w
  */
 export function substituteInStr(str: string, macros: Record<string, string>): string {
   return str.replace(/\$\(([^)]+)\)/g, (match) => macros[match] ?? match);
+}
+
+/**
+ * Build the built-in per-widget macro map from resolved PV data.
+ * Keys follow the same $(NAME) convention as user macros so they flow
+ * through substituteInStr / substituteTextProps unchanged.
+ *
+ * @param substitutedPVName The widget's PV name after user macros are applied.
+ * @param pvData            Resolved PV data for this widget (may be undefined).
+ */
+export function buildInternalMacros(
+  substitutedPVName: string | undefined,
+  pvData: PVData | undefined,
+): Record<string, string> {
+  const macros: Record<string, string> = {};
+  if (substitutedPVName) macros["$(pvname)"] = substitutedPVName;
+  if (pvData?.display?.description) macros["$(pvdesc)"] = pvData.display.description;
+  if (pvData?.display?.units) macros["$(pvunits)"] = pvData.display.units;
+  if (pvData?.value !== undefined)
+    macros["$(pvvalue)"] = Array.isArray(pvData.value)
+      ? pvData.value.join(", ")
+      : String(pvData.value);
+  return macros;
 }
 
 /**
@@ -33,7 +57,7 @@ export function substituteTextProps(
       const substituted = substituteInStr(prop.value, macros);
       resultRecord[key] = substituted !== prop.value ? { ...prop, value: substituted } : prop;
     } else if (prop.selType === "strList" && Array.isArray(prop.value)) {
-      const original = prop.value as string[];
+      const original = prop.value;
       const substituted = original.map((s) => substituteInStr(s, macros));
       resultRecord[key] = substituted.some((s, i) => s !== original[i])
         ? { ...prop, value: substituted }


### PR DESCRIPTION
- Macro replacement now works for all text input fields from the user (label, tooltip, axis names, etc.)
- Add internal special macros: `$(pvname)`, `$(pvdesc)`, `$(pvvalue)` and `$(pvunits)`. More may be added soon (closes #30).
- `$(pvname) - $(pvdesc)` is now the default tooltip, except for cases where not applicable (multi-pv or no PV at all).