### PR TITLE
feat: Add PV snapshot save/restore support

### DIFF
--- a/backend/epicsWS/epicsWS.py
+++ b/backend/epicsWS/epicsWS.py
@@ -184,33 +184,30 @@ async def message_handler(ws: ServerConnection):
                     protocol, clean_name = parse_protocol(pv_name)
                     client = get_client(protocol)
                     if hasattr(client, "_latest_value"):
-                        raw = client._latest_value.get(
-                            pv_name
-                        ) or client._latest_value.get(clean_name)
+                        raw = client._latest_value.get(clean_name)
                         if raw is not None:
-                            val = raw.get("value")
-                            # Convert numpy types to Python native
-                            if hasattr(val, "item"):
-                                val = val.item()
+                            if protocol == PVA_PROVIDER_KEY:
+                                parsed = PVParser.pva_update(raw, clean_name)
+                            else:
+                                parsed = PVParser.ca_update(raw, clean_name)
                             snapshot_data[pv_name] = {
-                                "value": val,
-                                "alarm": raw.get("severity", 0),
-                                "timestamp": raw.get("timestamp", 0),
+                                "value": parsed["value"],
+                                "alarm": parsed["alarm"],
+                                "timeStamp": parsed["timeStamp"],
+                                "b64arr": parsed["b64arr"],
+                                "b64dtype": parsed["b64dtype"],
                             }
-                            # Add metadata if available
-                            meta = _pv_metadata.get(pv_name) or _pv_metadata.get(
-                                clean_name
-                            )
-                            if meta:
-                                if "display" in meta:
-                                    snapshot_data[pv_name]["display"] = meta["display"]
 
                 await ws.send(
                     json.dumps(
                         {
-                            "type": "snapshot",
-                            "pvs": snapshot_data,
-                            "count": len(snapshot_data),
+                            k: v
+                            for k, v in {
+                                "type": "snapshot",
+                                "pvs": snapshot_data,
+                                "count": len(snapshot_data),
+                            }.items()
+                            if v is not None
                         }
                     )
                 )

--- a/backend/epicsWS/epicsWS.py
+++ b/backend/epicsWS/epicsWS.py
@@ -183,12 +183,14 @@ async def message_handler(ws: ServerConnection):
                 for pv_name in ws_subscriptions.get(ws, set()):
                     protocol, clean_name = parse_protocol(pv_name)
                     client = get_client(protocol)
-                    if hasattr(client, '_latest_value'):
-                        raw = client._latest_value.get(pv_name) or client._latest_value.get(clean_name)
+                    if hasattr(client, "_latest_value"):
+                        raw = client._latest_value.get(
+                            pv_name
+                        ) or client._latest_value.get(clean_name)
                         if raw is not None:
                             val = raw.get("value")
                             # Convert numpy types to Python native
-                            if hasattr(val, 'item'):
+                            if hasattr(val, "item"):
                                 val = val.item()
                             snapshot_data[pv_name] = {
                                 "value": val,
@@ -196,16 +198,22 @@ async def message_handler(ws: ServerConnection):
                                 "timestamp": raw.get("timestamp", 0),
                             }
                             # Add metadata if available
-                            meta = _pv_metadata.get(pv_name) or _pv_metadata.get(clean_name)
+                            meta = _pv_metadata.get(pv_name) or _pv_metadata.get(
+                                clean_name
+                            )
                             if meta:
                                 if "display" in meta:
                                     snapshot_data[pv_name]["display"] = meta["display"]
 
-                await ws.send(json.dumps({
-                    "type": "snapshot",
-                    "pvs": snapshot_data,
-                    "count": len(snapshot_data),
-                }))
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "snapshot",
+                            "pvs": snapshot_data,
+                            "count": len(snapshot_data),
+                        }
+                    )
+                )
 
             elif msg_type == "restore":
                 # Write saved PV values back to IOC
@@ -215,18 +223,28 @@ async def message_handler(ws: ServerConnection):
                     try:
                         protocol, clean_name = parse_protocol(pv_name)
                         client = get_client(protocol)
-                        value = pv_data if not isinstance(pv_data, dict) else pv_data.get("value")
+                        value = (
+                            pv_data
+                            if not isinstance(pv_data, dict)
+                            else pv_data.get("value")
+                        )
                         client.write_to_pv(clean_name, value)
                         results.append({"pv": pv_name, "success": True})
                     except Exception as e:
-                        results.append({"pv": pv_name, "success": False, "error": str(e)})
+                        results.append(
+                            {"pv": pv_name, "success": False, "error": str(e)}
+                        )
 
-                await ws.send(json.dumps({
-                    "type": "restore_result",
-                    "results": results,
-                    "total": len(results),
-                    "succeeded": sum(1 for r in results if r["success"]),
-                }))
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "restore_result",
+                            "results": results,
+                            "total": len(results),
+                            "succeeded": sum(1 for r in results if r["success"]),
+                        }
+                    )
+                )
 
             else:
                 await ws.send(

--- a/backend/epicsWS/epicsWS.py
+++ b/backend/epicsWS/epicsWS.py
@@ -177,6 +177,57 @@ async def message_handler(ws: ServerConnection):
                     client = get_client(protocol)
                     client.write_to_pv(pv_name, value)
 
+            elif msg_type == "snapshot":
+                # Capture current values of all subscribed PVs
+                snapshot_data = {}
+                for pv_name in ws_subscriptions.get(ws, set()):
+                    protocol, clean_name = parse_protocol(pv_name)
+                    client = get_client(protocol)
+                    if hasattr(client, '_latest_value'):
+                        raw = client._latest_value.get(pv_name) or client._latest_value.get(clean_name)
+                        if raw is not None:
+                            val = raw.get("value")
+                            # Convert numpy types to Python native
+                            if hasattr(val, 'item'):
+                                val = val.item()
+                            snapshot_data[pv_name] = {
+                                "value": val,
+                                "alarm": raw.get("severity", 0),
+                                "timestamp": raw.get("timestamp", 0),
+                            }
+                            # Add metadata if available
+                            meta = _pv_metadata.get(pv_name) or _pv_metadata.get(clean_name)
+                            if meta:
+                                if "display" in meta:
+                                    snapshot_data[pv_name]["display"] = meta["display"]
+
+                await ws.send(json.dumps({
+                    "type": "snapshot",
+                    "pvs": snapshot_data,
+                    "count": len(snapshot_data),
+                }))
+
+            elif msg_type == "restore":
+                # Write saved PV values back to IOC
+                pvs_to_restore = msg.get("pvs", {})
+                results = []
+                for pv_name, pv_data in pvs_to_restore.items():
+                    try:
+                        protocol, clean_name = parse_protocol(pv_name)
+                        client = get_client(protocol)
+                        value = pv_data if not isinstance(pv_data, dict) else pv_data.get("value")
+                        client.write_to_pv(clean_name, value)
+                        results.append({"pv": pv_name, "success": True})
+                    except Exception as e:
+                        results.append({"pv": pv_name, "success": False, "error": str(e)})
+
+                await ws.send(json.dumps({
+                    "type": "restore_result",
+                    "results": results,
+                    "total": len(results),
+                    "succeeded": sum(1 for r in results if r["success"]),
+                }))
+
             else:
                 await ws.send(
                     json.dumps({"type": "error", "message": "Unknown message type"})

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -32,6 +32,9 @@ import MicrosoftIcon from "@mui/icons-material/Microsoft";
 import { Roles, type OAuthProvider } from "@src/services/AuthService/AuthService.ts";
 import { OAuthProviders } from "@src/services/AuthService/AuthService.ts";
 import GitImportDialog from "@components/GitImportDialog/GitImportDialog.tsx";
+import SnapshotDialog from "@components/SnapshotDialog/SnapshotDialog.tsx";
+import CameraAltIcon from "@mui/icons-material/CameraAlt";
+import { useEpicsWSContext } from "@src/context/useEpicsWSContext.tsx";
 import { notifyUser } from "@src/services/Notifications/Notification.ts";
 import { useWidgetContext } from "@src/context/useWidgetContext.tsx";
 import { useUIContext } from "@src/context/useUIContext.tsx";
@@ -117,6 +120,8 @@ export default function NavBar() {
     isDeveloper,
     selectedFile,
   } = useUIContext();
+  const { takeSnapshot, restoreFromSnapshot } = useEpicsWSContext();
+  const [snapshotOpen, setSnapshotOpen] = useState(false);
   const drawerWidth = WIDGET_SELECTOR_WIDTH;
   const [importMenuAnchor, setImportMenuAnchor] = useState<null | HTMLElement>(null);
   const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(null);
@@ -280,6 +285,15 @@ export default function NavBar() {
                     </MenuItem>
                   )}
                 </Menu>
+				<Tooltip title="PV Snapshots">
+                  <Button
+                    onClick={() => setSnapshotOpen(true)}
+                    startIcon={<CameraAltIcon />}
+                    sx={{ color: "white", textTransform: "none" }}
+                  >
+                    Snapshots
+                  </Button>
+                </Tooltip>
                 <HelpOverlay />
                 <Tooltip title="View source on GitHub">
                   <IconButton
@@ -367,6 +381,12 @@ export default function NavBar() {
             )}
           </Box>
           <GitImportDialog open={gitImportOpen} onClose={() => setGitImportOpen(false)} />
+		  <SnapshotDialog
+            open={snapshotOpen}
+            onClose={() => setSnapshotOpen(false)}
+            onTakeSnapshot={takeSnapshot}
+            onRestore={restoreFromSnapshot}
+          />
         </Toolbar>
       </StyledAppBar>
     </Box>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -285,7 +285,7 @@ export default function NavBar() {
                     </MenuItem>
                   )}
                 </Menu>
-				<Tooltip title="PV Snapshots">
+                <Tooltip title="PV Snapshots">
                   <Button
                     onClick={() => setSnapshotOpen(true)}
                     startIcon={<CameraAltIcon />}
@@ -381,7 +381,7 @@ export default function NavBar() {
             )}
           </Box>
           <GitImportDialog open={gitImportOpen} onClose={() => setGitImportOpen(false)} />
-		  <SnapshotDialog
+          <SnapshotDialog
             open={snapshotOpen}
             onClose={() => setSnapshotOpen(false)}
             onTakeSnapshot={takeSnapshot}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -285,15 +285,17 @@ export default function NavBar() {
                     </MenuItem>
                   )}
                 </Menu>
-                <Tooltip title="PV Snapshots">
-                  <Button
-                    onClick={() => setSnapshotOpen(true)}
-                    startIcon={<CameraAltIcon />}
-                    sx={{ color: "white", textTransform: "none" }}
-                  >
-                    Snapshots
-                  </Button>
-                </Tooltip>
+                {!inEditMode && (
+                  <Tooltip title="PV Snapshots">
+                    <Button
+                      onClick={() => setSnapshotOpen(true)}
+                      startIcon={<CameraAltIcon />}
+                      sx={{ color: "white", textTransform: "none" }}
+                    >
+                      Snapshots
+                    </Button>
+                  </Tooltip>
+                )}
                 <HelpOverlay />
                 <Tooltip title="View source on GitHub">
                   <IconButton
@@ -378,6 +380,14 @@ export default function NavBar() {
                   ]}
                 </Menu>
               </>
+            )}
+            {!inEditMode && (
+              <SnapshotDialog
+                open={snapshotOpen}
+                onClose={() => setSnapshotOpen(false)}
+                onTakeSnapshot={takeSnapshot}
+                onRestore={restoreFromSnapshot}
+              />
             )}
           </Box>
           <GitImportDialog open={gitImportOpen} onClose={() => setGitImportOpen(false)} />

--- a/src/components/SnapshotDialog/SnapshotDialog.tsx
+++ b/src/components/SnapshotDialog/SnapshotDialog.tsx
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Snapshot Save/Restore for WEISS
+// Contributed by Elmaddin Guliyev 2026/05/18
+
+import { useState, useCallback } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import Alert from "@mui/material/Alert";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import DeleteIcon from "@mui/icons-material/Delete";
+import RestoreIcon from "@mui/icons-material/Restore";
+import CompareArrowsIcon from "@mui/icons-material/CompareArrows";
+import SaveIcon from "@mui/icons-material/Save";
+import CameraAltIcon from "@mui/icons-material/CameraAlt";
+import type { PVValue } from "@src/types/epicsWS";
+
+interface SnapshotEntry {
+  name: string;
+  timestamp: string;
+  pvs: Record<string, { value: PVValue; alarm?: number; timestamp?: number }>;
+  count: number;
+}
+
+interface SnapshotDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onTakeSnapshot: () => Promise<Record<string, unknown> | null>;
+  onRestore: (pvs: Record<string, { value: PVValue }>) => Promise<Record<string, unknown> | null>;
+}
+
+const STORAGE_KEY = "weiss-snapshots";
+
+function loadSnapshots(): SnapshotEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveSnapshots(snapshots: SnapshotEntry[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshots));
+}
+
+export default function SnapshotDialog({
+  open,
+  onClose,
+  onTakeSnapshot,
+  onRestore,
+}: SnapshotDialogProps) {
+  const [snapshots, setSnapshots] = useState<SnapshotEntry[]>(loadSnapshots);
+  const [snapshotName, setSnapshotName] = useState("");
+  const [tab, setTab] = useState(0);
+  const [status, setStatus] = useState<{ message: string; severity: "success" | "error" | "info" } | null>(null);
+  const [compareIdx, setCompareIdx] = useState<[number, number] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    if (!snapshotName.trim()) {
+      setStatus({ message: "Please enter a snapshot name", severity: "error" });
+      return;
+    }
+    setLoading(true);
+    setStatus({ message: "Capturing PV values...", severity: "info" });
+
+    try {
+      const result = await onTakeSnapshot();
+      if (result && "pvs" in result) {
+        const pvs = result.pvs as Record<string, { value: PVValue; alarm?: number; timestamp?: number }>;
+        const count = (result.count as number) || Object.keys(pvs).length;
+        const entry: SnapshotEntry = {
+          name: snapshotName.trim(),
+          timestamp: new Date().toISOString(),
+          pvs,
+          count,
+        };
+        const updated = [entry, ...snapshots];
+        setSnapshots(updated);
+        saveSnapshots(updated);
+        setSnapshotName("");
+        setStatus({ message: `Saved "${entry.name}" with ${count} PVs`, severity: "success" });
+      } else {
+        setStatus({ message: "Snapshot failed — no data returned. Are PVs subscribed in Runtime mode?", severity: "error" });
+      }
+    } catch (e) {
+      setStatus({ message: `Snapshot error: ${e}`, severity: "error" });
+    }
+    setLoading(false);
+  }, [snapshotName, snapshots, onTakeSnapshot]);
+
+  const handleRestore = useCallback(async (idx: number) => {
+    const snap = snapshots[idx];
+    if (!snap) return;
+    setLoading(true);
+    setStatus({ message: `Restoring ${snap.count} PVs from "${snap.name}"...`, severity: "info" });
+
+    try {
+      const pvData: Record<string, { value: PVValue }> = {};
+      for (const [pv, data] of Object.entries(snap.pvs)) {
+        pvData[pv] = { value: data.value };
+      }
+      const result = await onRestore(pvData);
+      if (result && "succeeded" in result) {
+        setStatus({
+          message: `Restored ${result.succeeded}/${result.total} PVs from "${snap.name}"`,
+          severity: (result.succeeded as number) === (result.total as number) ? "success" : "error",
+        });
+      } else {
+        setStatus({ message: "Restore failed", severity: "error" });
+      }
+    } catch (e) {
+      setStatus({ message: `Restore error: ${e}`, severity: "error" });
+    }
+    setLoading(false);
+  }, [snapshots, onRestore]);
+
+  const handleDelete = useCallback((idx: number) => {
+    const updated = snapshots.filter((_, i) => i !== idx);
+    setSnapshots(updated);
+    saveSnapshots(updated);
+    setStatus({ message: "Snapshot deleted", severity: "info" });
+  }, [snapshots]);
+
+  const handleCompare = useCallback((idx: number) => {
+    if (compareIdx === null) {
+      setCompareIdx([idx, -1]);
+      setStatus({ message: "Select a second snapshot to compare", severity: "info" });
+    } else if (compareIdx[1] === -1) {
+      setCompareIdx([compareIdx[0], idx]);
+      setTab(2);
+    }
+  }, [compareIdx]);
+
+  const cancelCompare = useCallback(() => {
+    setCompareIdx(null);
+    setStatus(null);
+  }, []);
+
+  // Compare two snapshots
+  const compareData = compareIdx && compareIdx[1] !== -1 ? (() => {
+    const a = snapshots[compareIdx[0]];
+    const b = snapshots[compareIdx[1]];
+    if (!a || !b) return [];
+    const allPVs = new Set([...Object.keys(a.pvs), ...Object.keys(b.pvs)]);
+    const diffs: { pv: string; valA: string; valB: string; changed: boolean }[] = [];
+    for (const pv of allPVs) {
+      const valA = a.pvs[pv]?.value ?? "N/A";
+      const valB = b.pvs[pv]?.value ?? "N/A";
+      diffs.push({
+        pv,
+        valA: String(valA),
+        valB: String(valB),
+        changed: String(valA) !== String(valB),
+      });
+    }
+    return diffs.sort((a, b) => (a.changed === b.changed ? a.pv.localeCompare(b.pv) : a.changed ? -1 : 1));
+  })() : [];
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <CameraAltIcon /> PV Snapshots
+      </DialogTitle>
+      <DialogContent>
+        {status && (
+          <Alert severity={status.severity} sx={{ mb: 2 }} onClose={() => setStatus(null)}>
+            {status.message}
+          </Alert>
+        )}
+
+        <Tabs value={tab} onChange={(_, v) => { setTab(v); cancelCompare(); }} sx={{ mb: 2 }}>
+          <Tab label="Save" />
+          <Tab label={`Saved (${snapshots.length})`} />
+          {compareIdx && compareIdx[1] !== -1 && <Tab label="Compare" />}
+        </Tabs>
+
+        {/* SAVE TAB */}
+        {tab === 0 && (
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Capture current values of all subscribed PVs. Make sure you are in
+              Runtime mode with PVs connected.
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <TextField
+                label="Snapshot name"
+                value={snapshotName}
+                onChange={(e) => setSnapshotName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") void handleSave(); }}
+                size="small"
+                fullWidth
+                placeholder="e.g., baseline_config, before_tuning"
+              />
+              <Button
+                variant="contained"
+                startIcon={<SaveIcon />}
+                onClick={() => void handleSave()}
+                disabled={loading || !snapshotName.trim()}
+                sx={{ whiteSpace: "nowrap" }}
+              >
+                Save
+              </Button>
+            </Box>
+          </Box>
+        )}
+
+        {/* SAVED LIST TAB */}
+        {tab === 1 && (
+          <Box>
+            {snapshots.length === 0 ? (
+              <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+                No snapshots saved yet. Go to the Save tab to capture one.
+              </Typography>
+            ) : (
+              <List dense>
+                {snapshots.map((snap, idx) => (
+                  <Box key={`${snap.name}-${snap.timestamp}`}>
+                    <ListItem>
+                      <ListItemText
+                        primary={snap.name}
+                        secondary={`${new Date(snap.timestamp).toLocaleString()} · ${snap.count} PVs`}
+                      />
+                      <ListItemSecondaryAction>
+                        <Chip label={`${snap.count} PVs`} size="small" sx={{ mr: 1 }} />
+                        <IconButton
+                          edge="end"
+                          title="Compare"
+                          onClick={() => handleCompare(idx)}
+                          color={compareIdx?.[0] === idx ? "primary" : "default"}
+                        >
+                          <CompareArrowsIcon />
+                        </IconButton>
+                        <IconButton
+                          edge="end"
+                          title="Restore"
+                          onClick={() => void handleRestore(idx)}
+                          disabled={loading}
+                          color="primary"
+                        >
+                          <RestoreIcon />
+                        </IconButton>
+                        <IconButton edge="end" title="Delete" onClick={() => handleDelete(idx)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </ListItemSecondaryAction>
+                    </ListItem>
+                    {idx < snapshots.length - 1 && <Divider />}
+                  </Box>
+                ))}
+              </List>
+            )}
+          </Box>
+        )}
+
+        {/* COMPARE TAB */}
+        {tab === 2 && compareIdx && compareIdx[1] !== -1 && (
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Comparing <strong>{snapshots[compareIdx[0]]?.name}</strong> vs{" "}
+              <strong>{snapshots[compareIdx[1]]?.name}</strong>
+              {" · "}
+              {compareData.filter((d) => d.changed).length} differences
+            </Typography>
+            <Box sx={{ maxHeight: 400, overflow: "auto" }}>
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid #333" }}>
+                    <th style={{ textAlign: "left", padding: "6px 8px" }}>PV</th>
+                    <th style={{ textAlign: "right", padding: "6px 8px" }}>{snapshots[compareIdx[0]]?.name}</th>
+                    <th style={{ textAlign: "right", padding: "6px 8px" }}>{snapshots[compareIdx[1]]?.name}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {compareData.map((row) => (
+                    <tr
+                      key={row.pv}
+                      style={{
+                        borderBottom: "1px solid #222",
+                        backgroundColor: row.changed ? "rgba(239,68,68,0.08)" : undefined,
+                      }}
+                    >
+                      <td style={{ padding: "4px 8px", fontFamily: "monospace", fontSize: 12 }}>
+                        {row.pv}
+                      </td>
+                      <td style={{ padding: "4px 8px", textAlign: "right", fontFamily: "monospace" }}>
+                        {row.valA}
+                      </td>
+                      <td
+                        style={{
+                          padding: "4px 8px",
+                          textAlign: "right",
+                          fontFamily: "monospace",
+                          color: row.changed ? "#ef4444" : undefined,
+                          fontWeight: row.changed ? 600 : undefined,
+                        }}
+                      >
+                        {row.valB}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Box>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/SnapshotDialog/SnapshotDialog.tsx
+++ b/src/components/SnapshotDialog/SnapshotDialog.tsx
@@ -349,7 +349,7 @@ export default function SnapshotDialog({
                           padding: "4px 8px",
                           textAlign: "right",
                           fontFamily: "monospace",
-                          color: row.changed ? "#ef4444" : undefined,
+                          color: row.changed ? COLORS.major : undefined,
                           fontWeight: row.changed ? 600 : undefined,
                         }}
                       >

--- a/src/components/SnapshotDialog/SnapshotDialog.tsx
+++ b/src/components/SnapshotDialog/SnapshotDialog.tsx
@@ -47,7 +47,9 @@ const STORAGE_KEY = "weiss-snapshots";
 function loadSnapshots(): SnapshotEntry[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as SnapshotEntry[]) : [];
   } catch {
     return [];
   }
@@ -66,7 +68,10 @@ export default function SnapshotDialog({
   const [snapshots, setSnapshots] = useState<SnapshotEntry[]>(loadSnapshots);
   const [snapshotName, setSnapshotName] = useState("");
   const [tab, setTab] = useState(0);
-  const [status, setStatus] = useState<{ message: string; severity: "success" | "error" | "info" } | null>(null);
+  const [status, setStatus] = useState<{
+    message: string;
+    severity: "success" | "error" | "info";
+  } | null>(null);
   const [compareIdx, setCompareIdx] = useState<[number, number] | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -81,8 +86,11 @@ export default function SnapshotDialog({
     try {
       const result = await onTakeSnapshot();
       if (result && "pvs" in result) {
-        const pvs = result.pvs as Record<string, { value: PVValue; alarm?: number; timestamp?: number }>;
-        const count = (result.count as number) || Object.keys(pvs).length;
+        const pvs = result.pvs as Record<
+          string,
+          { value: PVValue; alarm?: number; timestamp?: number }
+        >;
+        const count = typeof result.count === "number" ? result.count : Object.keys(pvs).length;
         const entry: SnapshotEntry = {
           name: snapshotName.trim(),
           timestamp: new Date().toISOString(),
@@ -95,56 +103,72 @@ export default function SnapshotDialog({
         setSnapshotName("");
         setStatus({ message: `Saved "${entry.name}" with ${count} PVs`, severity: "success" });
       } else {
-        setStatus({ message: "Snapshot failed — no data returned. Are PVs subscribed in Runtime mode?", severity: "error" });
+        setStatus({
+          message: "Snapshot failed — no data returned. Are PVs subscribed in Runtime mode?",
+          severity: "error",
+        });
       }
     } catch (e) {
-      setStatus({ message: `Snapshot error: ${e}`, severity: "error" });
+      setStatus({ message: `Snapshot error: ${String(e)}`, severity: "error" });
     }
     setLoading(false);
   }, [snapshotName, snapshots, onTakeSnapshot]);
 
-  const handleRestore = useCallback(async (idx: number) => {
-    const snap = snapshots[idx];
-    if (!snap) return;
-    setLoading(true);
-    setStatus({ message: `Restoring ${snap.count} PVs from "${snap.name}"...`, severity: "info" });
+  const handleRestore = useCallback(
+    async (idx: number) => {
+      const snap = snapshots[idx];
+      if (!snap) return;
+      setLoading(true);
+      setStatus({
+        message: `Restoring ${snap.count} PVs from "${snap.name}"...`,
+        severity: "info",
+      });
 
-    try {
-      const pvData: Record<string, { value: PVValue }> = {};
-      for (const [pv, data] of Object.entries(snap.pvs)) {
-        pvData[pv] = { value: data.value };
+      try {
+        const pvData: Record<string, { value: PVValue }> = {};
+        for (const [pv, data] of Object.entries(snap.pvs)) {
+          pvData[pv] = { value: data.value };
+        }
+        const result = await onRestore(pvData);
+        if (result && "succeeded" in result) {
+          setStatus({
+            message: `Restored ${String(result.succeeded)}/${String(result.total)} PVs from "${snap.name}"`,
+            severity:
+              (result.succeeded as number) === (result.total as number) ? "success" : "error",
+          });
+        } else {
+          setStatus({ message: "Restore failed", severity: "error" });
+        }
+      } catch (e) {
+        setStatus({ message: `Restore error: ${String(e)}`, severity: "error" });
       }
-      const result = await onRestore(pvData);
-      if (result && "succeeded" in result) {
-        setStatus({
-          message: `Restored ${result.succeeded}/${result.total} PVs from "${snap.name}"`,
-          severity: (result.succeeded as number) === (result.total as number) ? "success" : "error",
-        });
-      } else {
-        setStatus({ message: "Restore failed", severity: "error" });
+      setLoading(false);
+    },
+    [snapshots, onRestore],
+  );
+
+  const handleDelete = useCallback(
+    (idx: number) => {
+      const updated = snapshots.filter((_, i) => i !== idx);
+      setSnapshots(updated);
+      saveSnapshots(updated);
+      setStatus({ message: "Snapshot deleted", severity: "info" });
+    },
+    [snapshots],
+  );
+
+  const handleCompare = useCallback(
+    (idx: number) => {
+      if (compareIdx === null) {
+        setCompareIdx([idx, -1]);
+        setStatus({ message: "Select a second snapshot to compare", severity: "info" });
+      } else if (compareIdx[1] === -1) {
+        setCompareIdx([compareIdx[0], idx]);
+        setTab(2);
       }
-    } catch (e) {
-      setStatus({ message: `Restore error: ${e}`, severity: "error" });
-    }
-    setLoading(false);
-  }, [snapshots, onRestore]);
-
-  const handleDelete = useCallback((idx: number) => {
-    const updated = snapshots.filter((_, i) => i !== idx);
-    setSnapshots(updated);
-    saveSnapshots(updated);
-    setStatus({ message: "Snapshot deleted", severity: "info" });
-  }, [snapshots]);
-
-  const handleCompare = useCallback((idx: number) => {
-    if (compareIdx === null) {
-      setCompareIdx([idx, -1]);
-      setStatus({ message: "Select a second snapshot to compare", severity: "info" });
-    } else if (compareIdx[1] === -1) {
-      setCompareIdx([compareIdx[0], idx]);
-      setTab(2);
-    }
-  }, [compareIdx]);
+    },
+    [compareIdx],
+  );
 
   const cancelCompare = useCallback(() => {
     setCompareIdx(null);
@@ -152,24 +176,29 @@ export default function SnapshotDialog({
   }, []);
 
   // Compare two snapshots
-  const compareData = compareIdx && compareIdx[1] !== -1 ? (() => {
-    const a = snapshots[compareIdx[0]];
-    const b = snapshots[compareIdx[1]];
-    if (!a || !b) return [];
-    const allPVs = new Set([...Object.keys(a.pvs), ...Object.keys(b.pvs)]);
-    const diffs: { pv: string; valA: string; valB: string; changed: boolean }[] = [];
-    for (const pv of allPVs) {
-      const valA = a.pvs[pv]?.value ?? "N/A";
-      const valB = b.pvs[pv]?.value ?? "N/A";
-      diffs.push({
-        pv,
-        valA: String(valA),
-        valB: String(valB),
-        changed: String(valA) !== String(valB),
-      });
-    }
-    return diffs.sort((a, b) => (a.changed === b.changed ? a.pv.localeCompare(b.pv) : a.changed ? -1 : 1));
-  })() : [];
+  const compareData =
+    compareIdx && compareIdx[1] !== -1
+      ? (() => {
+          const a = snapshots[compareIdx[0]];
+          const b = snapshots[compareIdx[1]];
+          if (!a || !b) return [];
+          const allPVs = new Set([...Object.keys(a.pvs), ...Object.keys(b.pvs)]);
+          const diffs: { pv: string; valA: string; valB: string; changed: boolean }[] = [];
+          for (const pv of allPVs) {
+            const valA = a.pvs[pv]?.value ?? "N/A";
+            const valB = b.pvs[pv]?.value ?? "N/A";
+            diffs.push({
+              pv,
+              valA: String(valA),
+              valB: String(valB),
+              changed: String(valA) !== String(valB),
+            });
+          }
+          return diffs.sort((a, b) =>
+            a.changed === b.changed ? a.pv.localeCompare(b.pv) : a.changed ? -1 : 1,
+          );
+        })()
+      : [];
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -183,7 +212,14 @@ export default function SnapshotDialog({
           </Alert>
         )}
 
-        <Tabs value={tab} onChange={(_, v) => { setTab(v); cancelCompare(); }} sx={{ mb: 2 }}>
+        <Tabs
+          value={tab}
+          onChange={(_, v: number) => {
+            setTab(v);
+            cancelCompare();
+          }}
+          sx={{ mb: 2 }}
+        >
           <Tab label="Save" />
           <Tab label={`Saved (${snapshots.length})`} />
           {compareIdx && compareIdx[1] !== -1 && <Tab label="Compare" />}
@@ -193,15 +229,17 @@ export default function SnapshotDialog({
         {tab === 0 && (
           <Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Capture current values of all subscribed PVs. Make sure you are in
-              Runtime mode with PVs connected.
+              Capture current values of all subscribed PVs. Make sure you are in Runtime mode with
+              PVs connected.
             </Typography>
             <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
               <TextField
                 label="Snapshot name"
                 value={snapshotName}
                 onChange={(e) => setSnapshotName(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") void handleSave(); }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void handleSave();
+                }}
                 size="small"
                 fullWidth
                 placeholder="e.g., baseline_config, before_tuning"
@@ -281,8 +319,12 @@ export default function SnapshotDialog({
                 <thead>
                   <tr style={{ borderBottom: "1px solid #333" }}>
                     <th style={{ textAlign: "left", padding: "6px 8px" }}>PV</th>
-                    <th style={{ textAlign: "right", padding: "6px 8px" }}>{snapshots[compareIdx[0]]?.name}</th>
-                    <th style={{ textAlign: "right", padding: "6px 8px" }}>{snapshots[compareIdx[1]]?.name}</th>
+                    <th style={{ textAlign: "right", padding: "6px 8px" }}>
+                      {snapshots[compareIdx[0]]?.name}
+                    </th>
+                    <th style={{ textAlign: "right", padding: "6px 8px" }}>
+                      {snapshots[compareIdx[1]]?.name}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -297,7 +339,9 @@ export default function SnapshotDialog({
                       <td style={{ padding: "4px 8px", fontFamily: "monospace", fontSize: 12 }}>
                         {row.pv}
                       </td>
-                      <td style={{ padding: "4px 8px", textAlign: "right", fontFamily: "monospace" }}>
+                      <td
+                        style={{ padding: "4px 8px", textAlign: "right", fontFamily: "monospace" }}
+                      >
                         {row.valA}
                       </td>
                       <td

--- a/src/components/SnapshotDialog/SnapshotDialog.tsx
+++ b/src/components/SnapshotDialog/SnapshotDialog.tsx
@@ -230,8 +230,7 @@ export default function SnapshotDialog({
         {tab === 0 && (
           <Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Capture current values of all subscribed PVs. Make sure you are in Runtime mode with
-              PVs connected.
+              Capture current values of all subscribed PVs.
             </Typography>
             <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
               <TextField
@@ -318,7 +317,7 @@ export default function SnapshotDialog({
             <Box sx={{ maxHeight: 400, overflow: "auto" }}>
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                 <thead>
-                  <tr style={{ borderBottom: "1px solid ${COLORS.gridLineColor}" }}>
+                  <tr style={{ borderBottom: `1px solid ${COLORS.gridLineColor}` }}>
                     <th style={{ textAlign: "left", padding: "6px 8px" }}>PV</th>
                     <th style={{ textAlign: "right", padding: "6px 8px" }}>
                       {snapshots[compareIdx[0]]?.name}
@@ -334,7 +333,7 @@ export default function SnapshotDialog({
                       key={row.pv}
                       style={{
                         borderBottom: `1px solid ${COLORS.gridLineColor}`,
-                        backgroundColor: row.changed ? "rgba(239,68,68,0.08)" : undefined,
+                        backgroundColor: row.changed ? `${COLORS.major}14` : undefined,
                       }}
                     >
                       <td style={{ padding: "4px 8px", fontFamily: "monospace", fontSize: 12 }}>

--- a/src/components/SnapshotDialog/SnapshotDialog.tsx
+++ b/src/components/SnapshotDialog/SnapshotDialog.tsx
@@ -27,6 +27,7 @@ import CompareArrowsIcon from "@mui/icons-material/CompareArrows";
 import SaveIcon from "@mui/icons-material/Save";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import type { PVValue } from "@src/types/epicsWS";
+import { COLORS } from "@src/constants/constants";
 
 interface SnapshotEntry {
   name: string;
@@ -104,7 +105,7 @@ export default function SnapshotDialog({
         setStatus({ message: `Saved "${entry.name}" with ${count} PVs`, severity: "success" });
       } else {
         setStatus({
-          message: "Snapshot failed — no data returned. Are PVs subscribed in Runtime mode?",
+          message: "Snapshot failed — no data returned. Please, check PV names and try again.",
           severity: "error",
         });
       }
@@ -317,7 +318,7 @@ export default function SnapshotDialog({
             <Box sx={{ maxHeight: 400, overflow: "auto" }}>
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                 <thead>
-                  <tr style={{ borderBottom: "1px solid #333" }}>
+                  <tr style={{ borderBottom: "1px solid ${COLORS.gridLineColor}" }}>
                     <th style={{ textAlign: "left", padding: "6px 8px" }}>PV</th>
                     <th style={{ textAlign: "right", padding: "6px 8px" }}>
                       {snapshots[compareIdx[0]]?.name}
@@ -332,7 +333,7 @@ export default function SnapshotDialog({
                     <tr
                       key={row.pv}
                       style={{
-                        borderBottom: "1px solid #222",
+                        borderBottom: `1px solid ${COLORS.gridLineColor}`,
                         backgroundColor: row.changed ? "rgba(239,68,68,0.08)" : undefined,
                       }}
                     >

--- a/src/context/useEpicsWS.ts
+++ b/src/context/useEpicsWS.ts
@@ -158,7 +158,7 @@ export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["P
   const writePVValue = useCallback((pv: string, newValue: PVValue) => {
     ws.current?.write(pv, newValue);
   }, []);
-/**
+  /**
    * Takes a snapshot of all currently subscribed PV values.
    */
   const takeSnapshot = useCallback(async (): Promise<Record<string, unknown> | null> => {
@@ -175,18 +175,21 @@ export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["P
   /**
    * Restores PV values from a saved snapshot.
    */
-  const restoreFromSnapshot = useCallback(async (pvs: Record<string, { value: PVValue }>): Promise<Record<string, unknown> | null> => {
-    if (!ws.current) return null;
-    try {
-      const result = await ws.current.restoreSnapshot(pvs);
-      return result;
-    } catch (e) {
-      console.error("Restore failed:", e);
-      return null;
-    }
-  }, []);
-  
-return {
+  const restoreFromSnapshot = useCallback(
+    async (pvs: Record<string, { value: PVValue }>): Promise<Record<string, unknown> | null> => {
+      if (!ws.current) return null;
+      try {
+        const result = await ws.current.restoreSnapshot(pvs);
+        return result;
+      } catch (e) {
+        console.error("Restore failed:", e);
+        return null;
+      }
+    },
+    [],
+  );
+
+  return {
     ws,
     wsConnected,
     startNewSession,

--- a/src/context/useEpicsWS.ts
+++ b/src/context/useEpicsWS.ts
@@ -158,13 +158,42 @@ export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["P
   const writePVValue = useCallback((pv: string, newValue: PVValue) => {
     ws.current?.write(pv, newValue);
   }, []);
+/**
+   * Takes a snapshot of all currently subscribed PV values.
+   */
+  const takeSnapshot = useCallback(async (): Promise<Record<string, unknown> | null> => {
+    if (!ws.current) return null;
+    try {
+      const result = await ws.current.requestSnapshot();
+      return result;
+    } catch (e) {
+      console.error("Snapshot failed:", e);
+      return null;
+    }
+  }, []);
 
-  return {
+  /**
+   * Restores PV values from a saved snapshot.
+   */
+  const restoreFromSnapshot = useCallback(async (pvs: Record<string, { value: PVValue }>): Promise<Record<string, unknown> | null> => {
+    if (!ws.current) return null;
+    try {
+      const result = await ws.current.restoreSnapshot(pvs);
+      return result;
+    } catch (e) {
+      console.error("Restore failed:", e);
+      return null;
+    }
+  }, []);
+  
+return {
     ws,
     wsConnected,
     startNewSession,
     stopSession,
     writePVValue,
+    takeSnapshot,
+    restoreFromSnapshot,
     pvState,
   };
 }

--- a/src/services/WSClient/WSClient.ts
+++ b/src/services/WSClient/WSClient.ts
@@ -220,6 +220,66 @@ export class WSClient {
     this.socket.send(JSON.stringify({ type: "write", pv, value }));
   }
 
+/**
+   * Requests a snapshot of all currently subscribed PV values.
+   * @returns A promise that resolves with the snapshot data.
+   */
+  requestSnapshot(): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.connected) {
+        reject(new Error("Not connected"));
+        return;
+      }
+
+      const handler = (event: MessageEvent) => {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "snapshot") {
+          this.socket.removeEventListener("message", handler);
+          resolve(msg);
+        }
+      };
+      this.socket.addEventListener("message", handler);
+
+      // Timeout after 5 seconds
+      setTimeout(() => {
+        this.socket.removeEventListener("message", handler);
+        reject(new Error("Snapshot timeout"));
+      }, 5000);
+
+      this.socket.send(JSON.stringify({ type: "snapshot" }));
+    });
+  }
+
+  /**
+   * Restores PV values from a saved snapshot.
+   * @param pvs Record of PV names to their saved values.
+   * @returns A promise that resolves with the restore results.
+   */
+  restoreSnapshot(pvs: Record<string, { value: PVValue }>): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.connected) {
+        reject(new Error("Not connected"));
+        return;
+      }
+
+      const handler = (event: MessageEvent) => {
+        const msg = JSON.parse(event.data as string);
+        if (msg.type === "restore_result") {
+          this.socket.removeEventListener("message", handler);
+          resolve(msg);
+        }
+      };
+      this.socket.addEventListener("message", handler);
+
+      setTimeout(() => {
+        this.socket.removeEventListener("message", handler);
+        reject(new Error("Restore timeout"));
+      }, 10000);
+
+      this.socket.send(JSON.stringify({ type: "restore", pvs }));
+    });
+  }
+
   /**
    * Closes the WebSocket connection.
    */

--- a/src/services/WSClient/WSClient.ts
+++ b/src/services/WSClient/WSClient.ts
@@ -220,7 +220,7 @@ export class WSClient {
     this.socket.send(JSON.stringify({ type: "write", pv, value }));
   }
 
-/**
+  /**
    * Requests a snapshot of all currently subscribed PV values.
    * @returns A promise that resolves with the snapshot data.
    */
@@ -232,7 +232,7 @@ export class WSClient {
       }
 
       const handler = (event: MessageEvent) => {
-        const msg = JSON.parse(event.data as string);
+        const msg = JSON.parse(event.data as string) as Record<string, unknown>;
         if (msg.type === "snapshot") {
           this.socket.removeEventListener("message", handler);
           resolve(msg);
@@ -263,7 +263,7 @@ export class WSClient {
       }
 
       const handler = (event: MessageEvent) => {
-        const msg = JSON.parse(event.data as string);
+        const msg = JSON.parse(event.data as string) as Record<string, unknown>;
         if (msg.type === "restore_result") {
           this.socket.removeEventListener("message", handler);
           resolve(msg);

--- a/src/types/epicsWS.ts
+++ b/src/types/epicsWS.ts
@@ -3,7 +3,14 @@
 
 /** Type of a WebSocket message, indicating the operation or event */
 //export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write";
-export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write" | "snapshot" | "restore" | "restore_result";
+export type WSMessageType =
+  | "update"
+  | "subscribe"
+  | "unsubscribe"
+  | "write"
+  | "snapshot"
+  | "restore"
+  | "restore_result";
 /** Possible PV values: scalar or array of numbers or strings */
 export type PVValue = number | number[] | string | string[];
 

--- a/src/types/epicsWS.ts
+++ b/src/types/epicsWS.ts
@@ -2,8 +2,8 @@
 // Copyright (C) 2026 André Favoto
 
 /** Type of a WebSocket message, indicating the operation or event */
-export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write";
-
+//export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write";
+export type WSMessageType = "update" | "subscribe" | "unsubscribe" | "write" | "snapshot" | "restore" | "restore_result";
 /** Possible PV values: scalar or array of numbers or strings */
 export type PVValue = number | number[] | string | string[];
 


### PR DESCRIPTION
Hi André,

This PR adds PV snapshot save/restore functionality to WEISS, as discussed in our email exchange.

## What it does

- **Save**: Captures current values of all subscribed PVs in Runtime mode
- **Restore**: Writes saved PV values back to the IOC via the existing WebSocket write mechanism
- **Compare**: Side-by-side diff between two snapshots, highlighting changed values
- **Delete**: Remove snapshots no longer needed

## How it works

### Backend (epicsWS)
Two new WebSocket message types:
- `snapshot` — reads `_latest_value` from CAClient for all subscribed PVs and returns them as JSON
- `restore` — iterates saved PV values and calls `write_to_pv` for each, returning success/failure per PV

### Frontend
- `WSClient.ts` — added `requestSnapshot()` and `restoreSnapshot()` methods
- `useEpicsWS.ts` — exposed `takeSnapshot` and `restoreFromSnapshot` via the hook
- `SnapshotDialog.tsx` — new Material UI dialog with Save/Saved/Compare tabs
- `NavBar.tsx` — added Snapshots button next to Export/Import

Snapshots are stored in browser localStorage for simplicity. A future improvement could persist them server-side via the FastAPI backend.

### Testing
Tested against a simulated X-ray imaging system IOC (EPICS R7.0.8.1) with 62 records across 5 subsystems. Save, restore, and compare all verified working.

## Screenshots
The Snapshots button appears in the NavBar. The dialog provides Save, Saved list, and Compare tabs.

Happy to iterate on feedback!

Best regards,
  Elmaddin