### PR TITLE
feat: add alarm summary panel with severity filtering

### DIFF
--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -58,8 +58,8 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
   const alarmPVs = useMemo(() => {
     return Object.entries(pvState)
       .filter(([, data]) => data.alarm && data.alarm.severity > 0)
-      .map(([pv, data]) => ({
-        pv,
+      .map(([, data]) => ({
+        pv: data.pv,
         value: data.value,
         severity: data.alarm?.severity ?? 0,
         message: data.alarm?.message ?? "",

--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -31,13 +31,13 @@ const SEVERITY_LABELS: Record<number, string> = {
 
 const SEVERITY_COLORS: Record<number, string> = {
   0: COLORS.onColor,
-  1: "#f0c505",
+  1: COLORS.minorDark,
   2: COLORS.major,
   3: COLORS.invalid,
 };
 
 const SEVERITY_ICONS: Record<number, React.ReactNode> = {
-  1: <WarningAmberIcon fontSize="small" sx={{ color: "#f0c505" }} />,
+  1: <WarningAmberIcon fontSize="small" sx={{ color: COLORS.minorDark }} />,
   2: <ErrorIcon fontSize="small" sx={{ color: COLORS.major }} />,
   3: <HelpIcon fontSize="small" sx={{ color: COLORS.invalid }} />,
 };
@@ -158,7 +158,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
             }}
           >
             <ToggleButton value="all">All ({String(alarmPVs.length)})</ToggleButton>
-            <ToggleButton value="minor" sx={{ color: "#f0c505" }}>
+            <ToggleButton value="minor" sx={{ color: COLORS.minorDark }}>
               Minor ({String(counts.minor)})
             </ToggleButton>
             <ToggleButton value="major" sx={{ color: COLORS.major }}>

--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -21,6 +21,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import { COLORS } from "@src/constants/constants";
 import type { PVData } from "@src/types/epicsWS";
+import { useWidgetContext } from "@src/context/useWidgetContext";
 
 const SEVERITY_LABELS: Record<number, string> = {
   0: "NO_ALARM",
@@ -53,13 +54,14 @@ type SeverityFilter = "all" | "minor" | "major" | "invalid";
 export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) {
   const [search, setSearch] = useState("");
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const { PVMap } = useWidgetContext();
 
   // Collect all PVs in alarm
   const alarmPVs = useMemo(() => {
     return Object.entries(pvState)
       .filter(([, data]) => data.alarm && data.alarm.severity > 0)
       .map(([, data]) => ({
-        pv: data.pv,
+        pv: PVMap.get(data.pv) ?? data.pv,
         value: data.value,
         severity: data.alarm?.severity ?? 0,
         message: data.alarm?.message ?? "",
@@ -68,7 +70,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
         precision: data.display?.precision,
       }))
       .sort((a, b) => b.severity - a.severity || a.pv.localeCompare(b.pv));
-  }, [pvState]);
+  }, [pvState, PVMap]);
 
   // Apply filters
   const filteredPVs = useMemo(() => {

--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Alarm summary panel for WEISS
+// Contributed by Elmaddin Guliyev
+
+import { useState, useMemo } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
+import TextField from "@mui/material/TextField";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import ErrorIcon from "@mui/icons-material/Error";
+import HelpIcon from "@mui/icons-material/Help";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
+import { COLORS } from "@src/constants/constants";
+import type { PVData } from "@src/types/epicsWS";
+
+const SEVERITY_LABELS: Record<number, string> = {
+  0: "NO_ALARM",
+  1: "MINOR",
+  2: "MAJOR",
+  3: "INVALID",
+};
+
+const SEVERITY_COLORS: Record<number, string> = {
+  0: COLORS.onColor,
+  1: COLORS.minor,
+  2: COLORS.major,
+  3: COLORS.invalid,
+};
+
+const SEVERITY_ICONS: Record<number, React.ReactNode> = {
+  1: <WarningAmberIcon fontSize="small" sx={{ color: COLORS.minor }} />,
+  2: <ErrorIcon fontSize="small" sx={{ color: COLORS.major }} />,
+  3: <HelpIcon fontSize="small" sx={{ color: COLORS.invalid }} />,
+};
+
+interface AlarmPanelProps {
+  open: boolean;
+  onClose: () => void;
+  pvState: Record<string, PVData>;
+}
+
+type SeverityFilter = "all" | "minor" | "major" | "invalid";
+
+export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) {
+  const [search, setSearch] = useState("");
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+
+  // Collect all PVs in alarm
+  const alarmPVs = useMemo(() => {
+    return Object.entries(pvState)
+      .filter(([, data]) => data.alarm && data.alarm.severity > 0)
+      .map(([pv, data]) => ({
+        pv,
+        value: data.value,
+        severity: data.alarm?.severity ?? 0,
+        message: data.alarm?.message ?? "",
+        timestamp: data.timeStamp,
+        units: data.display?.units ?? "",
+      }))
+      .sort((a, b) => b.severity - a.severity || a.pv.localeCompare(b.pv));
+  }, [pvState]);
+
+  // Apply filters
+  const filteredPVs = useMemo(() => {
+    return alarmPVs.filter((item) => {
+      const matchSearch = !search || item.pv.toLowerCase().includes(search.toLowerCase());
+      const matchSeverity =
+        severityFilter === "all" ||
+        (severityFilter === "minor" && item.severity === 1) ||
+        (severityFilter === "major" && item.severity === 2) ||
+        (severityFilter === "invalid" && item.severity === 3);
+      return matchSearch && matchSeverity;
+    });
+  }, [alarmPVs, search, severityFilter]);
+
+  // Counts per severity
+  const counts = useMemo(() => {
+    const c = { minor: 0, major: 0, invalid: 0 };
+    alarmPVs.forEach((item) => {
+      if (item.severity === 1) c.minor++;
+      else if (item.severity === 2) c.major++;
+      else if (item.severity === 3) c.invalid++;
+    });
+    return c;
+  }, [alarmPVs]);
+
+  const formatTimestamp = (ts?: { secondsPastEpoch: number; nanoseconds: number }) => {
+    if (!ts?.secondsPastEpoch) return "--";
+    const date = new Date(ts.secondsPastEpoch * 1000);
+    return date.toLocaleTimeString();
+  };
+
+  const formatValue = (value: PVData["value"], units: string) => {
+    if (value === undefined || value === null) return "--";
+    if (typeof value === "number") return `${value.toFixed(2)} ${units}`.trim();
+    return `${String(value)} ${units}`.trim();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <NotificationsActiveIcon />
+        Alarm Summary
+        {alarmPVs.length > 0 ? (
+          <Chip
+            label={`${String(alarmPVs.length)} active`}
+            size="small"
+            sx={{
+              ml: 1,
+              backgroundColor: `${COLORS.major}20`,
+              color: COLORS.major,
+              fontWeight: 600,
+            }}
+          />
+        ) : (
+          <Chip
+            label="No alarms"
+            size="small"
+            sx={{
+              ml: 1,
+              backgroundColor: `${COLORS.onColor}20`,
+              color: COLORS.onColor,
+              fontWeight: 600,
+            }}
+          />
+        )}
+      </DialogTitle>
+      <DialogContent>
+        {/* Filter bar */}
+        <Box sx={{ display: "flex", gap: 2, mb: 2, alignItems: "center" }}>
+          <TextField
+            size="small"
+            placeholder="Filter by PV name..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            sx={{ flex: 1 }}
+          />
+          <ToggleButtonGroup
+            size="small"
+            value={severityFilter}
+            exclusive
+            onChange={(_, val: SeverityFilter | null) => {
+              if (val) setSeverityFilter(val);
+            }}
+          >
+            <ToggleButton value="all">All ({String(alarmPVs.length)})</ToggleButton>
+            <ToggleButton value="minor" sx={{ color: COLORS.minor }}>
+              Minor ({String(counts.minor)})
+            </ToggleButton>
+            <ToggleButton value="major" sx={{ color: COLORS.major }}>
+              Major ({String(counts.major)})
+            </ToggleButton>
+            <ToggleButton value="invalid" sx={{ color: COLORS.invalid }}>
+              Invalid ({String(counts.invalid)})
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+
+        {/* Alarm list */}
+        {filteredPVs.length === 0 ? (
+          <Box sx={{ py: 4, textAlign: "center" }}>
+            <CheckCircleIcon sx={{ fontSize: 48, color: COLORS.onColor, mb: 1 }} />
+            <Typography color="text.secondary">
+              {alarmPVs.length === 0
+                ? "No PVs are currently in alarm."
+                : "No alarms match the current filter."}
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ maxHeight: 400, overflow: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+              <thead>
+                <tr style={{ borderBottom: `2px solid ${COLORS.gridLineColor}` }}>
+                  <th style={{ textAlign: "left", padding: "8px", width: 30 }}></th>
+                  <th style={{ textAlign: "left", padding: "8px" }}>PV Name</th>
+                  <th style={{ textAlign: "left", padding: "8px" }}>Severity</th>
+                  <th style={{ textAlign: "right", padding: "8px" }}>Value</th>
+                  <th style={{ textAlign: "right", padding: "8px" }}>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredPVs.map((item) => (
+                  <tr
+                    key={item.pv}
+                    style={{
+                      borderBottom: `1px solid ${COLORS.gridLineColor}`,
+                      backgroundColor: `${SEVERITY_COLORS[item.severity]}10`,
+                    }}
+                  >
+                    <td style={{ padding: "6px 8px" }}>{SEVERITY_ICONS[item.severity]}</td>
+                    <td style={{ padding: "6px 8px", fontFamily: "monospace", fontSize: 12 }}>
+                      {item.pv}
+                    </td>
+                    <td style={{ padding: "6px 8px" }}>
+                      <Chip
+                        label={SEVERITY_LABELS[item.severity]}
+                        size="small"
+                        sx={{
+                          backgroundColor: `${SEVERITY_COLORS[item.severity]}20`,
+                          color: SEVERITY_COLORS[item.severity],
+                          fontWeight: 600,
+                          fontSize: 11,
+                        }}
+                      />
+                    </td>
+                    <td
+                      style={{
+                        padding: "6px 8px",
+                        textAlign: "right",
+                        fontFamily: "monospace",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {formatValue(item.value, item.units)}
+                    </td>
+                    <td
+                      style={{
+                        padding: "6px 8px",
+                        textAlign: "right",
+                        fontFamily: "monospace",
+                        fontSize: 11,
+                        color: COLORS.midGray,
+                      }}
+                    >
+                      {formatTimestamp(item.timestamp)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -31,13 +31,13 @@ const SEVERITY_LABELS: Record<number, string> = {
 
 const SEVERITY_COLORS: Record<number, string> = {
   0: COLORS.onColor,
-  1: COLORS.highlighted,
+  1: "#f0c505",
   2: COLORS.major,
   3: COLORS.invalid,
 };
 
 const SEVERITY_ICONS: Record<number, React.ReactNode> = {
-  1: <WarningAmberIcon fontSize="small" sx={{ color: COLORS.highlighted }} />,
+  1: <WarningAmberIcon fontSize="small" sx={{ color: "#f0c505" }} />,
   2: <ErrorIcon fontSize="small" sx={{ color: COLORS.major }} />,
   3: <HelpIcon fontSize="small" sx={{ color: COLORS.invalid }} />,
 };
@@ -158,7 +158,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
             }}
           >
             <ToggleButton value="all">All ({String(alarmPVs.length)})</ToggleButton>
-            <ToggleButton value="minor" sx={{ color: COLORS.highlighted }}>
+            <ToggleButton value="minor" sx={{ color: "#f0c505" }}>
               Minor ({String(counts.minor)})
             </ToggleButton>
             <ToggleButton value="major" sx={{ color: COLORS.major }}>

--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -31,7 +31,7 @@ const SEVERITY_LABELS: Record<number, string> = {
 
 const SEVERITY_COLORS: Record<number, string> = {
   0: COLORS.onColor,
-  1: COLORS.minor,
+  1: COLORS.gitModified,
   2: COLORS.major,
   3: COLORS.invalid,
 };
@@ -65,6 +65,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
         message: data.alarm?.message ?? "",
         timestamp: data.timeStamp,
         units: data.display?.units ?? "",
+        precision: data.display?.precision,
       }))
       .sort((a, b) => b.severity - a.severity || a.pv.localeCompare(b.pv));
   }, [pvState]);
@@ -99,9 +100,13 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
     return date.toLocaleTimeString();
   };
 
-  const formatValue = (value: PVData["value"], units: string) => {
+  const formatValue = (value: PVData["value"], units: string, precision?: number) => {
     if (value === undefined || value === null) return "--";
-    if (typeof value === "number") return `${value.toFixed(2)} ${units}`.trim();
+    if (typeof value === "number") {
+      const formatted =
+        precision !== undefined && precision >= 0 ? value.toFixed(precision) : String(value);
+      return `${formatted} ${units}`.trim();
+    }
     return `${String(value)} ${units}`.trim();
   };
 
@@ -220,7 +225,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
                         fontWeight: 600,
                       }}
                     >
-                      {formatValue(item.value, item.units)}
+                      {formatValue(item.value, item.units, item.precision)}
                     </td>
                     <td
                       style={{

--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -31,13 +31,13 @@ const SEVERITY_LABELS: Record<number, string> = {
 
 const SEVERITY_COLORS: Record<number, string> = {
   0: COLORS.onColor,
-  1: COLORS.gitModified,
+  1: COLORS.highlighted,
   2: COLORS.major,
   3: COLORS.invalid,
 };
 
 const SEVERITY_ICONS: Record<number, React.ReactNode> = {
-  1: <WarningAmberIcon fontSize="small" sx={{ color: COLORS.minor }} />,
+  1: <WarningAmberIcon fontSize="small" sx={{ color: COLORS.highlighted }} />,
   2: <ErrorIcon fontSize="small" sx={{ color: COLORS.major }} />,
   3: <HelpIcon fontSize="small" sx={{ color: COLORS.invalid }} />,
 };
@@ -158,7 +158,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
             }}
           >
             <ToggleButton value="all">All ({String(alarmPVs.length)})</ToggleButton>
-            <ToggleButton value="minor" sx={{ color: COLORS.minor }}>
+            <ToggleButton value="minor" sx={{ color: COLORS.highlighted }}>
               Minor ({String(counts.minor)})
             </ToggleButton>
             <ToggleButton value="major" sx={{ color: COLORS.major }}>

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -33,6 +33,8 @@ import { Roles, type OAuthProvider } from "@src/services/AuthService/AuthService
 import { OAuthProviders } from "@src/services/AuthService/AuthService.ts";
 import GitImportDialog from "@components/GitImportDialog/GitImportDialog.tsx";
 import SnapshotDialog from "@components/SnapshotDialog/SnapshotDialog.tsx";
+import AlarmPanel from "@components/AlarmPanel/AlarmPanel.tsx";
+import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import { useEpicsWSContext } from "@src/context/useEpicsWSContext.tsx";
 import { notifyUser } from "@src/services/Notifications/Notification.ts";
@@ -120,13 +122,14 @@ export default function NavBar() {
     isDeveloper,
     selectedFile,
   } = useUIContext();
-  const { takeSnapshot, restoreFromSnapshot } = useEpicsWSContext();
+  const { takeSnapshot, restoreFromSnapshot, pvState } = useEpicsWSContext();
   const [snapshotOpen, setSnapshotOpen] = useState(false);
+  const [alarmOpen, setAlarmOpen] = useState(false);
   const drawerWidth = WIDGET_SELECTOR_WIDTH;
   const [importMenuAnchor, setImportMenuAnchor] = useState<null | HTMLElement>(null);
   const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(null);
   const [gitImportOpen, setGitImportOpen] = useState(false);
-
+  const alarmCount = Object.values(pvState).filter((d) => d.alarm && d.alarm.severity > 0).length;
   const handleImportMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
     setImportMenuAnchor(event.currentTarget);
   };
@@ -286,6 +289,20 @@ export default function NavBar() {
                   )}
                 </Menu>
                 {!inEditMode && (
+                  <Tooltip title="Alarm Summary">
+                    <Button
+                      onClick={() => setAlarmOpen(true)}
+                      startIcon={<NotificationsActiveIcon />}
+                      sx={{
+                        color: alarmCount > 0 ? COLORS.major : "white",
+                        textTransform: "none",
+                      }}
+                    >
+                      Alarms{alarmCount > 0 ? ` (${String(alarmCount)})` : ""}
+                    </Button>
+                  </Tooltip>
+                )}
+                {!inEditMode && (
                   <Tooltip title="PV Snapshots">
                     <Button
                       onClick={() => setSnapshotOpen(true)}
@@ -388,6 +405,9 @@ export default function NavBar() {
                 onTakeSnapshot={takeSnapshot}
                 onRestore={restoreFromSnapshot}
               />
+            )}
+            {!inEditMode && (
+              <AlarmPanel open={alarmOpen} onClose={() => setAlarmOpen(false)} pvState={pvState} />
             )}
           </Box>
           <GitImportDialog open={gitImportOpen} onClose={() => setGitImportOpen(false)} />

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -37,6 +37,7 @@ export const COLORS = {
 
   // EPICS alarm colors
   minor: "#ffff00",
+  minorDark: "#f0c505",
   major: "#ff0000",
   invalid: "#5b00c4",
   disconnected: "#5b00c4",


### PR DESCRIPTION
- Added AlarmPanel component with real-time alarm summary dialog
- Show all PVs currently in alarm with severity, value, and timestamp
- Filter by severity (Minor/Major/Invalid) and search by PV name
- Alarm count badge in NavBar turns red when alarms are active
- Panel only visible in Runtime mode
- Uses COLORS constants and EPICS Normative Type alarm severities