### PR TITLE
feat: add Histogram widget for value distribution plots

### DIFF
--- a/src/components/Widgets/Histogram/Histogram.ts
+++ b/src/components/Widgets/Histogram/Histogram.ts
@@ -20,6 +20,8 @@ export const Histogram: WidgetDefinition = {
     width: { ...PROPERTY_SCHEMAS.width, value: 480 },
     height: { ...PROPERTY_SCHEMAS.height, value: 300 },
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: "white" },
+    lineColors: PROPERTY_SCHEMAS.lineColors,
+    plotBufferSize: PROPERTY_SCHEMAS.plotBufferSize,
     plotTitle: PROPERTY_SCHEMAS.plotTitle,
     xAxisTitle: PROPERTY_SCHEMAS.xAxisTitle,
     yAxisTitle: PROPERTY_SCHEMAS.yAxisTitle,

--- a/src/components/Widgets/Histogram/Histogram.ts
+++ b/src/components/Widgets/Histogram/Histogram.ts
@@ -20,7 +20,7 @@ export const Histogram: WidgetDefinition = {
     width: { ...PROPERTY_SCHEMAS.width, value: 480 },
     height: { ...PROPERTY_SCHEMAS.height, value: 300 },
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: "white" },
-    lineColors: PROPERTY_SCHEMAS.lineColors,
+    barColor: PROPERTY_SCHEMAS.barColor,
     plotBufferSize: PROPERTY_SCHEMAS.plotBufferSize,
     plotTitle: PROPERTY_SCHEMAS.plotTitle,
     xAxisTitle: PROPERTY_SCHEMAS.xAxisTitle,

--- a/src/components/Widgets/Histogram/Histogram.ts
+++ b/src/components/Widgets/Histogram/Histogram.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Histogram widget for WEISS
+// Contributed by Elmaddin Guliyev
+
+import { HistogramComp } from "./HistogramComp";
+import { COMMON_PROPS, PROPERTY_SCHEMAS, TEXT_PROPS } from "@src/types/widgetProperties";
+import type { WidgetDefinition } from "@src/types/widgets";
+import BarChartIcon from "@mui/icons-material/BarChart";
+
+export const Histogram: WidgetDefinition = {
+  component: HistogramComp,
+  widgetName: "Histogram",
+  widgetIcon: BarChartIcon,
+  widgetLabel: "Histogram",
+  category: "Monitoring",
+  defaultProperties: {
+    pvName: PROPERTY_SCHEMAS.pvName,
+    ...COMMON_PROPS,
+    tooltip: { ...PROPERTY_SCHEMAS.tooltip, value: "" },
+    width: { ...PROPERTY_SCHEMAS.width, value: 480 },
+    height: { ...PROPERTY_SCHEMAS.height, value: 300 },
+    backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: "white" },
+    plotTitle: PROPERTY_SCHEMAS.plotTitle,
+    xAxisTitle: PROPERTY_SCHEMAS.xAxisTitle,
+    yAxisTitle: PROPERTY_SCHEMAS.yAxisTitle,
+    ...TEXT_PROPS,
+    textVAlign: { ...PROPERTY_SCHEMAS.textVAlign, value: "top" },
+    textHAlign: { ...PROPERTY_SCHEMAS.textHAlign, value: "center" },
+  },
+};

--- a/src/components/Widgets/Histogram/HistogramComp.tsx
+++ b/src/components/Widgets/Histogram/HistogramComp.tsx
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Histogram widget for WEISS
+// Contributed by Elmaddin Guliyev
+
+import React, { useEffect, useState, useRef } from "react";
+import type { WidgetUpdate } from "@src/types/widgets";
+import Plot from "react-plotly.js";
+import { COLORS } from "@src/constants/constants";
+import type { TimeStamp } from "@src/types/epicsWS";
+import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
+import { useUIContext } from "@src/context/useUIContext";
+
+const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
+  const { inEditMode } = useUIContext();
+  const p = data.editableProperties;
+  const pvData = data.pvData;
+  const alarmData = pvData?.alarm;
+
+  const textHAlign = p.textHAlign?.value;
+  const textVAlign = p.textVAlign?.value;
+  const titleXpos = textHAlign === "left" ? 0.05 : textHAlign === "right" ? 0.95 : 0.5;
+  const titleYpos = textVAlign === "bottom" ? 0.05 : textVAlign === "middle" ? 0.5 : 0.95;
+
+  const valueBuffer = useRef<number[]>([]);
+  const prevTimestamp = useRef<TimeStamp | undefined>(undefined);
+  const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
+  const [layout, setLayout] = useState<Partial<Plotly.Layout>>({});
+
+  useEffect(() => {
+    if (inEditMode) {
+      valueBuffer.current = [];
+      const preview: number[] = [];
+      for (let i = 0; i < 200; i++) {
+        preview.push(
+          50 + 15 * Math.sqrt(-2 * Math.log(Math.random())) * Math.cos(2 * Math.PI * Math.random()),
+        );
+      }
+      setPlotData([
+        {
+          x: preview,
+          type: "histogram",
+          marker: { color: COLORS.highlighted },
+        } as Plotly.Data,
+      ]);
+      return;
+    }
+
+    if (!pvData) return;
+
+    const newTs = pvData.timeStamp;
+    if (newTs === prevTimestamp.current) return;
+    prevTimestamp.current = newTs;
+
+    const value = pvData.value;
+
+    if (Array.isArray(value)) {
+      setPlotData([
+        {
+          x: [...(value as number[])],
+          type: "histogram",
+          marker: { color: COLORS.highlighted },
+        } as Plotly.Data,
+      ]);
+    } else if (typeof value === "number") {
+      valueBuffer.current.push(value);
+      if (valueBuffer.current.length > 500) {
+        valueBuffer.current = valueBuffer.current.slice(-500);
+      }
+      setPlotData([
+        {
+          x: [...valueBuffer.current],
+          type: "histogram",
+          marker: { color: COLORS.highlighted },
+        } as Plotly.Data,
+      ]);
+    }
+  }, [inEditMode, pvData]);
+
+  useEffect(() => {
+    setLayout({
+      title: {
+        text: p.plotTitle?.value ?? "",
+        font: {
+          family: p.fontFamily?.value,
+          size: p.fontSize?.value,
+          weight: p.fontBold?.value ? 800 : 0,
+          style: p.fontItalic?.value ? "italic" : "normal",
+          lineposition: p.fontUnderlined?.value ? "under" : "none",
+          color: p.textColor?.value,
+        },
+        x: titleXpos,
+        y: titleYpos,
+      },
+      xaxis: {
+        title: {
+          text: p.xAxisTitle?.value ?? "",
+          font: {
+            family: p.fontFamily?.value,
+            size: (p.fontSize?.value ?? 12) - 2,
+            color: COLORS.lightGray,
+          },
+        },
+      },
+      yaxis: {
+        title: {
+          text: p.yAxisTitle?.value ?? "Count",
+          font: {
+            family: p.fontFamily?.value,
+            size: (p.fontSize?.value ?? 12) - 2,
+            color: COLORS.lightGray,
+          },
+        },
+      },
+      bargap: 0.05,
+      paper_bgcolor: p.backgroundColor?.value,
+      plot_bgcolor: p.backgroundColor?.value,
+      margin: { b: 45, l: 45, t: 50, r: 30 },
+      width: p.width?.value,
+      height: p.height?.value,
+      showlegend: false,
+      uirevision: String(inEditMode),
+    });
+  }, [p, inEditMode, titleXpos, titleYpos]);
+
+  return (
+    <AlarmBorder alarmData={alarmData} enable={p.alarmBorder?.value}>
+      <div
+        style={{
+          width: p.width?.value,
+          height: p.height?.value,
+          borderRadius: p.borderRadius?.value,
+          borderStyle: p.borderStyle?.value,
+          borderWidth: p.borderWidth?.value,
+          borderColor: p.borderColor?.value,
+          display: "flex",
+          overflow: "hidden",
+        }}
+      >
+        <Plot
+          data={plotData}
+          layout={layout}
+          config={{
+            responsive: true,
+            displaylogo: false,
+            staticPlot: inEditMode,
+          }}
+        />
+      </div>
+    </AlarmBorder>
+  );
+};
+
+export { HistogramComp };

--- a/src/components/Widgets/Histogram/HistogramComp.tsx
+++ b/src/components/Widgets/Histogram/HistogramComp.tsx
@@ -14,7 +14,7 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { inEditMode } = useUIContext();
   const p = data.editableProperties;
   const bufferSize: number = p.plotBufferSize?.value ?? 500;
-  const lineColors = p.lineColors?.value;
+  const barColor: string = p.barColor?.value ?? COLORS.highlighted;
   const pvData = data.pvData;
   const alarmData = pvData?.alarm;
 
@@ -41,7 +41,7 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         {
           x: preview,
           type: "histogram",
-          marker: { color: lineColors?.[0] ?? COLORS.highlighted },
+          marker: { color: barColor },
         } as Plotly.Data,
       ]);
       return;
@@ -60,7 +60,7 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         {
           x: [...(value as number[])],
           type: "histogram",
-          marker: { color: lineColors?.[0] ?? COLORS.highlighted },
+          marker: { color: barColor },
         } as Plotly.Data,
       ]);
     } else if (typeof value === "number") {
@@ -72,11 +72,11 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         {
           x: [...valueBuffer.current],
           type: "histogram",
-          marker: { color: lineColors?.[0] ?? COLORS.highlighted },
+          marker: { color: barColor },
         } as Plotly.Data,
       ]);
     }
-  }, [inEditMode, pvData, bufferSize, lineColors]);
+  }, [inEditMode, pvData, bufferSize, barColor]);
 
   useEffect(() => {
     setLayout({

--- a/src/components/Widgets/Histogram/HistogramComp.tsx
+++ b/src/components/Widgets/Histogram/HistogramComp.tsx
@@ -13,6 +13,8 @@ import { useUIContext } from "@src/context/useUIContext";
 const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { inEditMode } = useUIContext();
   const p = data.editableProperties;
+  const bufferSize: number = p.plotBufferSize?.value ?? 500;
+  const lineColors = p.lineColors?.value;
   const pvData = data.pvData;
   const alarmData = pvData?.alarm;
 
@@ -39,7 +41,7 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         {
           x: preview,
           type: "histogram",
-          marker: { color: COLORS.highlighted },
+          marker: { color: lineColors?.[0] ?? COLORS.highlighted },
         } as Plotly.Data,
       ]);
       return;
@@ -58,23 +60,23 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         {
           x: [...(value as number[])],
           type: "histogram",
-          marker: { color: COLORS.highlighted },
+          marker: { color: lineColors?.[0] ?? COLORS.highlighted },
         } as Plotly.Data,
       ]);
     } else if (typeof value === "number") {
       valueBuffer.current.push(value);
-      if (valueBuffer.current.length > 500) {
-        valueBuffer.current = valueBuffer.current.slice(-500);
+      if (valueBuffer.current.length > bufferSize) {
+        valueBuffer.current = valueBuffer.current.slice(-bufferSize);
       }
       setPlotData([
         {
           x: [...valueBuffer.current],
           type: "histogram",
-          marker: { color: COLORS.highlighted },
+          marker: { color: lineColors?.[0] ?? COLORS.highlighted },
         } as Plotly.Data,
       ]);
     }
-  }, [inEditMode, pvData]);
+  }, [inEditMode, pvData, bufferSize, lineColors]);
 
   useEffect(() => {
     setLayout({

--- a/src/components/Widgets/Histogram/index.ts
+++ b/src/components/Widgets/Histogram/index.ts
@@ -1,0 +1,1 @@
+export { Histogram } from "./Histogram";

--- a/src/components/Widgets/index.ts
+++ b/src/components/Widgets/index.ts
@@ -19,3 +19,4 @@ export { EmbeddedDisplay } from "./EmbeddedDisplay";
 export { NavigationButton } from "./NavigationButton";
 export { Spinner } from "./Spinner";
 export { GraphXY } from "./GraphXY";
+export { Histogram } from "./Histogram";


### PR DESCRIPTION
Hi Andre,

This adds the Histogram widget — the last plot improvement from your list.

## What it does

Displays value distributions as a histogram using PlotlyJS.

Two modes:
- **Scalar PVs**: Accumulates values in a ring buffer (500 max), builds histogram over time — useful for monitoring value stability and drift
- **Array PVs**: Plots distribution of array values directly — useful for detector pixel distributions

## How it works

- Single PV input (pvName)
- Edit mode shows preview with Gaussian sample data
- Uses PlotlyJS consistent with GraphY, GraphXY, and Heatmap
- Configurable title, axis labels, background
- Alarm border support
- BarChart icon in Monitoring category

Tested with XRAY:HV:VoltRead — histogram shows voltage distribution around setpoint.