### PR TITLE
feat: add LLM-powered operator assistant chat panel

### DIFF
--- a/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/components/ChatPanel/ChatPanel.tsx
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// LLM Chat Panel for WEISS — EPICS operator assistant
+// Contributed by Elmaddin Guliyev
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import SendIcon from "@mui/icons-material/Send";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
+import PersonIcon from "@mui/icons-material/Person";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import CircularProgress from "@mui/material/CircularProgress";
+import Chip from "@mui/material/Chip";
+import { COLORS } from "@src/constants/constants";
+import type { PVData, PVValue } from "@src/types/epicsWS";
+
+const OLLAMA_URL = "http://localhost:11434/api/generate";
+const MODEL = "qwen2.5-coder:1.5b";
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  commands?: string[];
+}
+
+interface ChatPanelProps {
+  open: boolean;
+  onClose: () => void;
+  pvState: Record<string, PVData>;
+  writePVValue: (pv: string, value: PVValue) => void;
+}
+
+function buildSystemPrompt(pvState: Record<string, PVData>): string {
+  const pvList = Object.entries(pvState)
+    .map(([name, data]) => {
+      const val = data.value;
+      const units = data.display?.units ?? "";
+      const low = data.display?.limitLow;
+      const high = data.display?.limitHigh;
+      const alarm = data.alarm?.severity ?? 0;
+      const alarmStr =
+        alarm === 0
+          ? ""
+          : alarm === 1
+            ? " [MINOR ALARM]"
+            : alarm === 2
+              ? " [MAJOR ALARM]"
+              : " [INVALID]";
+      let range = "";
+      if (low !== undefined && high !== undefined) {
+        range = ` (range: ${String(low)}-${String(high)} ${units})`;
+      }
+      return `  ${name} = ${String(val)} ${units}${range}${alarmStr}`;
+    })
+    .join("\n");
+
+  return `You are an EPICS control system operator assistant for WEISS.
+Your job is to help operators interact with the control system using natural language.
+
+RULES:
+1. The caput command syntax is: caput PV_NAME VALUE
+2. PV values are in engineering units shown below
+3. Always check ranges before suggesting values
+4. For safety-critical operations, warn the operator
+5. When suggesting commands, put each on its own line starting with "caput "
+6. Be concise and direct
+
+CURRENTLY SUBSCRIBED PVs AND VALUES:
+${pvList}
+
+Answer the operator's question based on the PV data above.`;
+}
+
+function extractCommands(text: string): string[] {
+  const lines = text.split("\n");
+  const commands: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim().replace(/^`+|`+$/g, "");
+    if (trimmed.startsWith("caput ")) {
+      commands.push(trimmed);
+    }
+  }
+  return commands;
+}
+
+export default function ChatPanel({ open, onClose, pvState, writePVValue }: ChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [ollamaStatus, setOllamaStatus] = useState<"checking" | "online" | "offline">("checking");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Check Ollama status
+  useEffect(() => {
+    if (!open) return;
+    setOllamaStatus("checking");
+    fetch("http://localhost:11434/api/tags")
+      .then((res) => {
+        if (res.ok) setOllamaStatus("online");
+        else setOllamaStatus("offline");
+      })
+      .catch(() => setOllamaStatus("offline"));
+  }, [open]);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = useCallback(async () => {
+    if (!input.trim() || loading) return;
+
+    const userMessage: ChatMessage = { role: "user", content: input.trim() };
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const systemPrompt = buildSystemPrompt(pvState);
+      const res = await fetch(OLLAMA_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: MODEL,
+          prompt: `${systemPrompt}\n\nOperator: ${userMessage.content}\nAssistant:`,
+          stream: false,
+        }),
+      });
+
+      if (res.ok) {
+        const data = (await res.json()) as { response: string };
+        const commands = extractCommands(data.response);
+        const assistantMessage: ChatMessage = {
+          role: "assistant",
+          content: data.response,
+          commands,
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: "Failed to get response from LLM.",
+          },
+        ]);
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: "Cannot reach Ollama. Make sure it is running on localhost:11434.",
+        },
+      ]);
+    }
+    setLoading(false);
+  }, [input, loading, pvState]);
+
+  const executeCommand = useCallback(
+    (cmd: string) => {
+      const parts = cmd.split(/\s+/);
+      console.log("Execute command parts:", parts);
+      if (parts.length >= 3 && parts[0] === "caput") {
+        const pvName = parts[1];
+        const value = parts[2];
+        const numValue = Number(value);
+        console.log("Writing PV:", pvName, "Value:", isNaN(numValue) ? value : numValue);
+        writePVValue(pvName, isNaN(numValue) ? value : numValue);
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: `Executed: ${cmd}`,
+          },
+        ]);
+      }
+    },
+    [writePVValue],
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <SmartToyIcon />
+        EPICS Operator Assistant
+        <Chip
+          label={
+            ollamaStatus === "online"
+              ? `${MODEL}`
+              : ollamaStatus === "checking"
+                ? "Checking..."
+                : "Offline"
+          }
+          size="small"
+          sx={{
+            ml: 1,
+            backgroundColor:
+              ollamaStatus === "online"
+                ? `${COLORS.onColor}20`
+                : ollamaStatus === "offline"
+                  ? `${COLORS.major}20`
+                  : `${COLORS.gridLineColor}`,
+            color:
+              ollamaStatus === "online"
+                ? COLORS.onColor
+                : ollamaStatus === "offline"
+                  ? COLORS.major
+                  : COLORS.midGray,
+            fontWeight: 600,
+            fontSize: 11,
+          }}
+        />
+      </DialogTitle>
+      <DialogContent>
+        {/* Chat messages */}
+        <Box
+          sx={{
+            height: 400,
+            overflow: "auto",
+            mb: 2,
+            p: 1,
+            backgroundColor: COLORS.backgroundColor,
+            borderRadius: 1,
+          }}
+        >
+          {messages.length === 0 && (
+            <Typography color="text.secondary" sx={{ textAlign: "center", mt: 8 }}>
+              Ask me about the system status, suggest parameter changes, or request caput commands.
+            </Typography>
+          )}
+          {messages.map((msg, idx) => (
+            <Box
+              key={idx}
+              sx={{
+                display: "flex",
+                gap: 1,
+                mb: 1.5,
+                alignItems: "flex-start",
+              }}
+            >
+              {msg.role === "user" ? (
+                <PersonIcon fontSize="small" sx={{ color: COLORS.highlighted, mt: 0.5 }} />
+              ) : (
+                <SmartToyIcon fontSize="small" sx={{ color: COLORS.onColor, mt: 0.5 }} />
+              )}
+              <Box sx={{ flex: 1 }}>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    whiteSpace: "pre-wrap",
+                    fontFamily: msg.role === "assistant" ? "monospace" : "inherit",
+                    fontSize: msg.role === "assistant" ? 12 : 14,
+                  }}
+                >
+                  {msg.content}
+                </Typography>
+                {msg.commands && msg.commands.length > 0 && (
+                  <Box sx={{ mt: 1, display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+                    {msg.commands.map((cmd, cmdIdx) => (
+                      <Button
+                        key={cmdIdx}
+                        size="small"
+                        variant="outlined"
+                        startIcon={<PlayArrowIcon />}
+                        onClick={() => executeCommand(cmd)}
+                        sx={{
+                          textTransform: "none",
+                          fontFamily: "monospace",
+                          fontSize: 11,
+                        }}
+                      >
+                        {cmd}
+                      </Button>
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            </Box>
+          ))}
+          {loading && (
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <SmartToyIcon fontSize="small" sx={{ color: COLORS.onColor }} />
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">
+                Thinking...
+              </Typography>
+            </Box>
+          )}
+          <div ref={messagesEndRef} />
+        </Box>
+
+        {/* Input */}
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Ask about system status, suggest changes..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void handleSend();
+              }
+            }}
+            disabled={loading || ollamaStatus === "offline"}
+          />
+          <IconButton
+            color="primary"
+            onClick={() => void handleSend()}
+            disabled={loading || !input.trim() || ollamaStatus === "offline"}
+          >
+            <SendIcon />
+          </IconButton>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -40,6 +40,8 @@ import { useEpicsWSContext } from "@src/context/useEpicsWSContext.tsx";
 import { notifyUser } from "@src/services/Notifications/Notification.ts";
 import { useWidgetContext } from "@src/context/useWidgetContext.tsx";
 import { useUIContext } from "@src/context/useUIContext.tsx";
+import ChatPanel from "@components/ChatPanel/ChatPanel.tsx";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
 interface StyledAppBarProps extends MuiAppBarProps {
   open?: boolean;
   drawerWidth: number;
@@ -122,8 +124,10 @@ export default function NavBar() {
     isDeveloper,
     selectedFile,
   } = useUIContext();
-  const { takeSnapshot, restoreFromSnapshot, pvState } = useEpicsWSContext();
+  //const { takeSnapshot, restoreFromSnapshot, pvState } = useEpicsWSContext();
+  const { takeSnapshot, restoreFromSnapshot, pvState, writePVValue } = useEpicsWSContext();
   const [snapshotOpen, setSnapshotOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const [alarmOpen, setAlarmOpen] = useState(false);
   const drawerWidth = WIDGET_SELECTOR_WIDTH;
   const [importMenuAnchor, setImportMenuAnchor] = useState<null | HTMLElement>(null);
@@ -313,6 +317,17 @@ export default function NavBar() {
                     </Button>
                   </Tooltip>
                 )}
+                {!inEditMode && (
+                  <Tooltip title="AI Assistant">
+                    <Button
+                      onClick={() => setChatOpen(true)}
+                      startIcon={<SmartToyIcon />}
+                      sx={{ color: "white", textTransform: "none" }}
+                    >
+                      AI
+                    </Button>
+                  </Tooltip>
+                )}
                 <HelpOverlay />
                 <Tooltip title="View source on GitHub">
                   <IconButton
@@ -404,6 +419,14 @@ export default function NavBar() {
                 onClose={() => setSnapshotOpen(false)}
                 onTakeSnapshot={takeSnapshot}
                 onRestore={restoreFromSnapshot}
+              />
+            )}
+            {!inEditMode && (
+              <ChatPanel
+                open={chatOpen}
+                onClose={() => setChatOpen(false)}
+                pvState={pvState}
+                writePVValue={writePVValue}
               />
             )}
             {!inEditMode && (


### PR DESCRIPTION
Hi Andre,

This adds an experimental LLM-powered chat panel to WEISS — an AI assistant that understands the live control system state and can generate caput commands from natural language.

## What it does

Operators can type natural language like:
- "What is the current system status?"
- "Set the voltage to 120 kV"
- "Open the shutter"

The LLM reads all currently subscribed PV names, values, ranges, units, and alarm states, then responds with explanations and executable caput commands.

## How it works

- **System prompt** auto-populated with live PV data from pvState
- **Ollama** runs locally (localhost:11434) with qwen2.5-coder:1.5b (1GB model, CPU-only)
- Browser calls Ollama API directly — no backend changes needed
- Extracts `caput` commands from LLM responses and shows **Execute** buttons
- One-click execution via existing writePVValue WebSocket mechanism
- Status indicator shows if Ollama is online/offline

## Architecture

WEISS Browser -> Ollama API (localhost:11434) -> qwen2.5-coder:1.5b
Execute button -> writePVValue -> epicsWS -> IOC

## Prerequisites

Ollama must be installed on the host machine:
curl -fsSL https://ollama.com/install.sh | sh ollama pull qwen2.5-coder:1.5b

## Notes

This is experimental — the LLM sometimes adds units to caput values or suggests incorrect ranges. The Execute button gives the operator explicit control before any command runs. No commands execute automatically.
The AI button appears in the NavBar only in Runtime mode.
Tested with simulated X-ray imaging IOC — status queries and voltage/current changes working.