### PR TITLE
ContextMenu: add runtime options 

### DIFF
--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -2,261 +2,43 @@
 // Copyright (C) 2026 André Favoto
 
 import * as React from "react";
-import Paper from "@mui/material/Paper";
-import MenuList from "@mui/material/MenuList";
-import MenuItem from "@mui/material/MenuItem";
-import ListItemText from "@mui/material/ListItemText";
-import ListItemIcon from "@mui/material/ListItemIcon";
-import Typography from "@mui/material/Typography";
-import { FRONT_UI_ZIDX } from "@src/constants/constants";
 import type { GridPosition } from "@src/types/widgets";
-
-import AlignVerticalTop from "@mui/icons-material/AlignVerticalTop";
-import AlignVerticalBottom from "@mui/icons-material/AlignVerticalBottom";
-import AlignHorizontalLeft from "@mui/icons-material/AlignHorizontalLeft";
-import AlignHorizontalRight from "@mui/icons-material/AlignHorizontalRight";
-import AlignVerticalCenter from "@mui/icons-material/AlignVerticalCenter";
-import AlignHorizontalCenter from "@mui/icons-material/AlignHorizontalCenter";
-import FlipToFront from "@mui/icons-material/FlipToFront";
-import FlipToBack from "@mui/icons-material/FlipToBack";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import CustomGroupIcon from "@components/CustomIcons/GroupIcon";
-import CustomUngroupIcon from "@components/CustomIcons/UngroupIcon";
-import ContentCopy from "@mui/icons-material/ContentCopy";
-import ContentPaste from "@mui/icons-material/ContentPaste";
-import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
-import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
-import FormatLineSpacingIcon from "@mui/icons-material/FormatLineSpacing";
-import ExpandIcon from "@mui/icons-material/Expand";
+import type { PVData } from "@src/types/epicsWS";
 import { useUIContext } from "@src/context/useUIContext";
-import { useWidgetContext } from "@src/context/useWidgetContext";
+import EditContextMenu from "./EditContextMenu";
+import RuntimeContextMenu from "./RuntimeContextMenu";
 
 export interface ContextMenuProps {
   pos: GridPosition;
   mousePos: GridPosition;
   visible: boolean;
   onClose: () => void;
+  pvName?: string | null;
+  pvData?: PVData | null;
 }
 
-const ContextMenu: React.FC<ContextMenuProps> = ({ pos, mousePos, visible, onClose }) => {
+const ContextMenu: React.FC<ContextMenuProps> = ({
+  pos,
+  mousePos,
+  visible,
+  onClose,
+  pvName = null,
+  pvData = null,
+}) => {
   const { inEditMode } = useUIContext();
-  const {
-    selectedWidgetIDs,
-    selectedWidgets,
-    bringToFront,
-    sendToBack,
-    alignTop,
-    alignBottom,
-    alignLeft,
-    alignRight,
-    alignVerticalCenter,
-    alignHorizontalCenter,
-    distributeHorizontal,
-    distributeVertical,
-    matchWidth,
-    matchHeight,
-    deleteWidget,
-    groupSelected,
-    ungroupSelected,
-    copyWidget,
-    pasteWidget,
-    stepForward,
-    stepBackwards,
-  } = useWidgetContext();
 
-  if (!visible) return null;
-  if (!inEditMode) return null; //TODO: add context menu for runtime
-
-  const noneSelected = selectedWidgetIDs.length === 0;
-  const lessThanTwoSelected = selectedWidgetIDs.length < 2;
-  const lessThanThreeSelected = selectedWidgetIDs.length < 3;
-  const hasGroupSelected = selectedWidgets.some((w) => w.widgetName === "Group");
-
-  const options = [
-    {
-      label: "Copy",
-      icon: <ContentCopy fontSize="small" />,
-      shortcut: "Ctrl+C",
-      action: () => copyWidget(),
-      disabled: noneSelected,
-    },
-    {
-      label: "Paste",
-      icon: <ContentPaste fontSize="small" />,
-      shortcut: "Ctrl+V",
-      action: () => pasteWidget(mousePos),
-      disabled: false,
-    },
-    { divider: true },
-    {
-      label: "Group",
-      icon: <CustomGroupIcon fontSize="small" />,
-      shortcut: "Ctrl+G",
-      action: () => groupSelected(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Ungroup",
-      icon: <CustomUngroupIcon fontSize="small" />,
-      shortcut: "Ctrl+U",
-      action: () => ungroupSelected(),
-      disabled: !hasGroupSelected,
-    },
-    { divider: true },
-    {
-      label: "Align left",
-      icon: <AlignHorizontalLeft fontSize="small" />,
-      action: () => alignLeft(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Align right",
-      icon: <AlignHorizontalRight fontSize="small" />,
-      action: () => alignRight(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Align top",
-      icon: <AlignVerticalTop fontSize="small" />,
-      action: () => alignTop(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Align bottom",
-      icon: <AlignVerticalBottom fontSize="small" />,
-      action: () => alignBottom(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Align vert. center",
-      icon: <AlignVerticalCenter fontSize="small" />,
-      action: () => alignVerticalCenter(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Align horiz. center",
-      icon: <AlignHorizontalCenter fontSize="small" />,
-      action: () => alignHorizontalCenter(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Distribute horizontally",
-      icon: <FormatLineSpacingIcon fontSize="small" sx={{ transform: "rotate(90deg)" }} />,
-      action: () => distributeHorizontal(),
-      disabled: lessThanThreeSelected,
-    },
-    {
-      label: "Distribute vertically",
-      icon: <FormatLineSpacingIcon fontSize="small" />,
-      action: () => distributeVertical(),
-      disabled: lessThanThreeSelected,
-    },
-    {
-      label: "Match width",
-      icon: <ExpandIcon fontSize="small" sx={{ transform: "rotate(90deg)" }} />,
-      action: () => matchWidth(),
-      disabled: lessThanTwoSelected,
-    },
-    {
-      label: "Match height",
-      icon: <ExpandIcon fontSize="small" />,
-      action: () => matchHeight(),
-      disabled: lessThanTwoSelected,
-    },
-    { divider: true },
-    {
-      label: "Bring to front",
-      icon: <FlipToFront fontSize="small" />,
-      action: () => bringToFront(),
-      disabled: noneSelected,
-    },
-    {
-      label: "Send to back",
-      icon: <FlipToBack fontSize="small" />,
-      action: () => sendToBack(),
-      disabled: noneSelected,
-    },
-    {
-      label: "Step forward",
-      icon: <KeyboardArrowUp fontSize="small" />,
-      action: () => stepForward(),
-      disabled: noneSelected,
-    },
-    {
-      label: "Step back",
-      icon: <KeyboardArrowDown fontSize="small" />,
-      action: () => stepBackwards(),
-      disabled: noneSelected,
-    },
-    { divider: true },
-    {
-      label: "Delete",
-      icon: <DeleteOutlineIcon fontSize="small" />,
-      shortcut: "Del",
-      action: () => deleteWidget(),
-      disabled: noneSelected,
-    },
-  ];
-  // calculate where to render context menu
-  const nDividers = options.filter((opt) => opt.divider).length;
-  const menuWidth = 220;
-  const padding = 8;
-  // Consider 32px per option (default) + 8px per divider + padding
-  const estimatedHeight = (options.length - nDividers) * 32 + nDividers * 8 + padding * 2;
-
-  let adjustedX = pos.x;
-  let adjustedY = pos.y;
-
-  if (adjustedX + menuWidth > window.innerWidth - padding) {
-    adjustedX = Math.max(padding, window.innerWidth - menuWidth - padding);
-  }
-
-  if (adjustedY + estimatedHeight > window.innerHeight - padding) {
-    adjustedY = Math.max(padding, window.innerHeight - estimatedHeight - padding);
+  if (inEditMode) {
+    return <EditContextMenu pos={pos} mousePos={mousePos} visible={visible} onClose={onClose} />;
   }
 
   return (
-    <Paper
-      className="contextMenu"
-      sx={{
-        position: "fixed",
-        left: adjustedX,
-        top: adjustedY,
-        zIndex: FRONT_UI_ZIDX,
-        width: menuWidth,
-        maxWidth: "100%",
-        boxShadow: 3,
-      }}
-      onMouseUp={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
-      onMouseMove={(e) => e.stopPropagation()}
-    >
-      <MenuList dense sx={{ zIndex: FRONT_UI_ZIDX }}>
-        {options.map((opt, index) =>
-          opt.divider ? (
-            <hr key={`divider-${index}`} style={{ margin: "4px 0", border: "0.5px solid #eee" }} />
-          ) : (
-            <MenuItem
-              key={index}
-              disabled={opt.disabled}
-              onClick={(e) => {
-                e.stopPropagation();
-                opt.action?.();
-                onClose();
-              }}
-            >
-              <ListItemIcon>{opt.icon}</ListItemIcon>
-              <ListItemText>{opt.label}</ListItemText>
-              {opt.shortcut && (
-                <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                  {opt.shortcut}
-                </Typography>
-              )}
-            </MenuItem>
-          ),
-        )}
-      </MenuList>
-    </Paper>
+    <RuntimeContextMenu
+      pos={pos}
+      visible={visible}
+      onClose={onClose}
+      pvName={pvName}
+      pvData={pvData}
+    />
   );
 };
 

--- a/src/components/ContextMenu/EditContextMenu.tsx
+++ b/src/components/ContextMenu/EditContextMenu.tsx
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import * as React from "react";
+import Paper from "@mui/material/Paper";
+import MenuList from "@mui/material/MenuList";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import Typography from "@mui/material/Typography";
+import { FRONT_UI_ZIDX } from "@src/constants/constants";
+import type { GridPosition } from "@src/types/widgets";
+
+import AlignVerticalTop from "@mui/icons-material/AlignVerticalTop";
+import AlignVerticalBottom from "@mui/icons-material/AlignVerticalBottom";
+import AlignHorizontalLeft from "@mui/icons-material/AlignHorizontalLeft";
+import AlignHorizontalRight from "@mui/icons-material/AlignHorizontalRight";
+import AlignVerticalCenter from "@mui/icons-material/AlignVerticalCenter";
+import AlignHorizontalCenter from "@mui/icons-material/AlignHorizontalCenter";
+import FlipToFront from "@mui/icons-material/FlipToFront";
+import FlipToBack from "@mui/icons-material/FlipToBack";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import CustomGroupIcon from "@components/CustomIcons/GroupIcon";
+import CustomUngroupIcon from "@components/CustomIcons/UngroupIcon";
+import ContentCopy from "@mui/icons-material/ContentCopy";
+import ContentPaste from "@mui/icons-material/ContentPaste";
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
+import FormatLineSpacingIcon from "@mui/icons-material/FormatLineSpacing";
+import ExpandIcon from "@mui/icons-material/Expand";
+import { useWidgetContext } from "@src/context/useWidgetContext";
+
+export interface EditContextMenuProps {
+  pos: GridPosition;
+  mousePos: GridPosition;
+  visible: boolean;
+  onClose: () => void;
+}
+
+const EditContextMenu: React.FC<EditContextMenuProps> = ({ pos, mousePos, visible, onClose }) => {
+  const {
+    selectedWidgetIDs,
+    selectedWidgets,
+    bringToFront,
+    sendToBack,
+    alignTop,
+    alignBottom,
+    alignLeft,
+    alignRight,
+    alignVerticalCenter,
+    alignHorizontalCenter,
+    distributeHorizontal,
+    distributeVertical,
+    matchWidth,
+    matchHeight,
+    deleteWidget,
+    groupSelected,
+    ungroupSelected,
+    copyWidget,
+    pasteWidget,
+    stepForward,
+    stepBackwards,
+  } = useWidgetContext();
+
+  if (!visible) return null;
+
+  const noneSelected = selectedWidgetIDs.length === 0;
+  const lessThanTwoSelected = selectedWidgetIDs.length < 2;
+  const lessThanThreeSelected = selectedWidgetIDs.length < 3;
+  const hasGroupSelected = selectedWidgets.some((w) => w.widgetName === "Group");
+
+  const options = [
+    {
+      label: "Copy",
+      icon: <ContentCopy fontSize="small" />,
+      shortcut: "Ctrl+C",
+      action: () => copyWidget(),
+      disabled: noneSelected,
+    },
+    {
+      label: "Paste",
+      icon: <ContentPaste fontSize="small" />,
+      shortcut: "Ctrl+V",
+      action: () => pasteWidget(mousePos),
+      disabled: false,
+    },
+    { divider: true },
+    {
+      label: "Group",
+      icon: <CustomGroupIcon fontSize="small" />,
+      shortcut: "Ctrl+G",
+      action: () => groupSelected(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Ungroup",
+      icon: <CustomUngroupIcon fontSize="small" />,
+      shortcut: "Ctrl+U",
+      action: () => ungroupSelected(),
+      disabled: !hasGroupSelected,
+    },
+    { divider: true },
+    {
+      label: "Align left",
+      icon: <AlignHorizontalLeft fontSize="small" />,
+      action: () => alignLeft(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Align right",
+      icon: <AlignHorizontalRight fontSize="small" />,
+      action: () => alignRight(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Align top",
+      icon: <AlignVerticalTop fontSize="small" />,
+      action: () => alignTop(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Align bottom",
+      icon: <AlignVerticalBottom fontSize="small" />,
+      action: () => alignBottom(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Align vert. center",
+      icon: <AlignVerticalCenter fontSize="small" />,
+      action: () => alignVerticalCenter(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Align horiz. center",
+      icon: <AlignHorizontalCenter fontSize="small" />,
+      action: () => alignHorizontalCenter(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Distribute horizontally",
+      icon: <FormatLineSpacingIcon fontSize="small" sx={{ transform: "rotate(90deg)" }} />,
+      action: () => distributeHorizontal(),
+      disabled: lessThanThreeSelected,
+    },
+    {
+      label: "Distribute vertically",
+      icon: <FormatLineSpacingIcon fontSize="small" />,
+      action: () => distributeVertical(),
+      disabled: lessThanThreeSelected,
+    },
+    {
+      label: "Match width",
+      icon: <ExpandIcon fontSize="small" sx={{ transform: "rotate(90deg)" }} />,
+      action: () => matchWidth(),
+      disabled: lessThanTwoSelected,
+    },
+    {
+      label: "Match height",
+      icon: <ExpandIcon fontSize="small" />,
+      action: () => matchHeight(),
+      disabled: lessThanTwoSelected,
+    },
+    { divider: true },
+    {
+      label: "Bring to front",
+      icon: <FlipToFront fontSize="small" />,
+      action: () => bringToFront(),
+      disabled: noneSelected,
+    },
+    {
+      label: "Send to back",
+      icon: <FlipToBack fontSize="small" />,
+      action: () => sendToBack(),
+      disabled: noneSelected,
+    },
+    {
+      label: "Step forward",
+      icon: <KeyboardArrowUp fontSize="small" />,
+      action: () => stepForward(),
+      disabled: noneSelected,
+    },
+    {
+      label: "Step back",
+      icon: <KeyboardArrowDown fontSize="small" />,
+      action: () => stepBackwards(),
+      disabled: noneSelected,
+    },
+    { divider: true },
+    {
+      label: "Delete",
+      icon: <DeleteOutlineIcon fontSize="small" />,
+      shortcut: "Del",
+      action: () => deleteWidget(),
+      disabled: noneSelected,
+    },
+  ];
+
+  // calculate where to render context menu
+  const nDividers = options.filter((opt) => opt.divider).length;
+  const menuWidth = 220;
+  const padding = 8;
+  // Consider 32px per option (default) + 8px per divider + padding
+  const estimatedHeight = (options.length - nDividers) * 32 + nDividers * 8 + padding * 2;
+
+  let adjustedX = pos.x;
+  let adjustedY = pos.y;
+
+  if (adjustedX + menuWidth > window.innerWidth - padding) {
+    adjustedX = Math.max(padding, window.innerWidth - menuWidth - padding);
+  }
+
+  if (adjustedY + estimatedHeight > window.innerHeight - padding) {
+    adjustedY = Math.max(padding, window.innerHeight - estimatedHeight - padding);
+  }
+
+  return (
+    <Paper
+      className="contextMenu"
+      sx={{
+        position: "fixed",
+        left: adjustedX,
+        top: adjustedY,
+        zIndex: FRONT_UI_ZIDX,
+        width: menuWidth,
+        maxWidth: "100%",
+        boxShadow: 3,
+      }}
+      onMouseUp={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onMouseMove={(e) => e.stopPropagation()}
+    >
+      <MenuList dense sx={{ zIndex: FRONT_UI_ZIDX }}>
+        {options.map((opt, index) =>
+          opt.divider ? (
+            <hr key={`divider-${index}`} style={{ margin: "4px 0", border: "0.5px solid #eee" }} />
+          ) : (
+            <MenuItem
+              key={index}
+              disabled={opt.disabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                opt.action?.();
+                onClose();
+              }}
+            >
+              <ListItemIcon>{opt.icon}</ListItemIcon>
+              <ListItemText>{opt.label}</ListItemText>
+              {opt.shortcut && (
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {opt.shortcut}
+                </Typography>
+              )}
+            </MenuItem>
+          ),
+        )}
+      </MenuList>
+    </Paper>
+  );
+};
+
+export default EditContextMenu;

--- a/src/components/ContextMenu/RuntimeContextMenu.tsx
+++ b/src/components/ContextMenu/RuntimeContextMenu.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import * as React from "react";
+import Paper from "@mui/material/Paper";
+import MenuList from "@mui/material/MenuList";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import Tooltip from "@mui/material/Tooltip";
+import { FRONT_UI_ZIDX } from "@src/constants/constants";
+import type { GridPosition } from "@src/types/widgets";
+import type { PVData } from "@src/types/epicsWS";
+
+import ContentCopy from "@mui/icons-material/ContentCopy";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import HistoryIcon from "@mui/icons-material/History";
+import { notifyUser } from "@src/services/Notifications/Notification";
+
+export interface RuntimeContextMenuProps {
+  pos: GridPosition;
+  visible: boolean;
+  onClose: () => void;
+  pvName: string | null;
+  pvData: PVData | null;
+}
+
+const RuntimeContextMenu: React.FC<RuntimeContextMenuProps> = ({
+  pos,
+  visible,
+  onClose,
+  pvName,
+  pvData,
+}) => {
+  if (!visible) return null;
+
+  const hasPV = pvName !== null && pvName !== "";
+  const hasValue = hasPV && pvData !== null;
+
+  const copyToClipboard = async (text: string) => {
+    await navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        notifyUser("Copied to clipboard", "success");
+      })
+      .catch(() => {
+        notifyUser("Failed to copy", "error");
+      });
+    onClose();
+  };
+
+  const formatValue = (data: PVData): string => String(data.value);
+  const formatTimestamp = (data: PVData): string => {
+    const seconds = data.timeStamp.secondsPastEpoch + data.timeStamp.nanoseconds / 1e9;
+    return new Date(seconds * 1000).toLocaleString("sv");
+  };
+
+  const menuWidth = 240;
+  const padding = 8;
+  // 3 active items + 1 divider + 2 disabled items
+  const estimatedHeight = 5 * 32 + 1 * 8 + padding * 2;
+
+  let adjustedX = pos.x;
+  let adjustedY = pos.y;
+
+  if (adjustedX + menuWidth > window.innerWidth - padding) {
+    adjustedX = Math.max(padding, window.innerWidth - menuWidth - padding);
+  }
+
+  if (adjustedY + estimatedHeight > window.innerHeight - padding) {
+    adjustedY = Math.max(padding, window.innerHeight - estimatedHeight - padding);
+  }
+
+  return (
+    <Paper
+      className="contextMenu"
+      sx={{
+        position: "fixed",
+        left: adjustedX,
+        top: adjustedY,
+        zIndex: FRONT_UI_ZIDX,
+        width: menuWidth,
+        maxWidth: "100%",
+        boxShadow: 3,
+      }}
+      onMouseUp={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onMouseMove={(e) => e.stopPropagation()}
+    >
+      <MenuList dense sx={{ zIndex: FRONT_UI_ZIDX }}>
+        <MenuItem
+          disabled={!hasPV}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasPV) {
+              void copyToClipboard(pvName);
+            }
+          }}
+        >
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy PV Name</ListItemText>
+        </MenuItem>
+
+        <MenuItem
+          disabled={!hasValue}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasValue) {
+              void copyToClipboard(formatValue(pvData));
+            }
+          }}
+        >
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy PV Value</ListItemText>
+        </MenuItem>
+
+        <MenuItem
+          disabled={!hasValue}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasValue) {
+              void copyToClipboard(`${formatTimestamp(pvData)} ${pvName} ${formatValue(pvData)}`);
+            }
+          }}
+        >
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy PV Name with Value</ListItemText>
+        </MenuItem>
+
+        <hr style={{ margin: "4px 0", border: "0.5px solid #eee" }} />
+
+        <Tooltip title="Coming soon" placement="right">
+          <span>
+            <MenuItem disabled>
+              <ListItemIcon>
+                <InfoOutlinedIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>PV Details</ListItemText>
+            </MenuItem>
+          </span>
+        </Tooltip>
+
+        <Tooltip title="Coming soon" placement="right">
+          <span>
+            <MenuItem disabled>
+              <ListItemIcon>
+                <HistoryIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>See PV History</ListItemText>
+            </MenuItem>
+          </span>
+        </Tooltip>
+      </MenuList>
+    </Paper>
+  );
+};
+
+export default RuntimeContextMenu;

--- a/src/components/GridZone/GridZoneComp.tsx
+++ b/src/components/GridZone/GridZoneComp.tsx
@@ -3,6 +3,8 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { GridPosition, WidgetDefinition, WidgetUpdate } from "@src/types/widgets";
+import type { PVData } from "@src/types/epicsWS";
+import { useEpicsWSContext } from "@src/context/useEpicsWSContext";
 import { createWidgetInstance } from "@src/context/widgetHelpers";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import {
@@ -62,7 +64,11 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     groupSelected,
     ungroupSelected,
     moveSelected,
+    PVMap,
+    widgetIdMap,
   } = useWidgetContext();
+
+  const { pvState } = useEpicsWSContext();
 
   const gridRef = useRef<HTMLDivElement>(null);
   const lastPosRef = useRef<GridPosition>({ x: 0, y: 0 });
@@ -73,6 +79,9 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
   const [pan, setPan] = useState<GridPosition>({ x: 0, y: 0 });
   const [contextMenuPos, setContextMenuPos] = useState<GridPosition>({ x: 0, y: 0 });
   const [contextMenuVisible, setContextMenuVisible] = useState(false);
+  const [contextMenuPVName, setContextMenuPVName] = useState<string | null>(null);
+  const [contextMenuPVData, setContextMenuPVData] = useState<PVData | null>(null);
+
   const [shouldCenterPan, setShouldCenterPan] = useState(true);
   const [dragPreview, setDragPreview] = useState<{
     widget: WidgetDefinition;
@@ -234,6 +243,29 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
       return;
     }
     setContextMenuPos({ x: e.clientX, y: e.clientY });
+
+    if (!inEditMode) {
+      // Walk up the DOM from the click target to find a widget
+      let el: Element | null = document.elementFromPoint(e.clientX, e.clientY);
+      let foundPVName: string | null = null;
+      let foundPVData: PVData | null = null;
+      while (el && el !== document.body) {
+        const widget = widgetIdMap.get(el.id);
+        if (widget) {
+          const rawPvName = widget.editableProperties.pvName?.value;
+          if (rawPvName) {
+            const substituted = PVMap.get(rawPvName) ?? rawPvName;
+            foundPVName = substituted;
+            foundPVData = pvState[rawPvName] ?? null;
+          }
+          break;
+        }
+        el = el.parentElement;
+      }
+      setContextMenuPVName(foundPVName);
+      setContextMenuPVData(foundPVData);
+    }
+
     setContextMenuVisible(true);
   };
 
@@ -445,6 +477,8 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
         onClose={() => {
           setContextMenuVisible(false);
         }}
+        pvName={contextMenuPVName}
+        pvData={contextMenuPVData}
       />
       {isReposLoading && (
         <Box

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -64,6 +64,22 @@ export function useWidgetManager() {
     [editorWidgets],
   );
 
+  /**
+   * Flat map of widget id -> Widget for all widgets (including nested group children).
+   * Excludes the grid itself.
+   */
+  const widgetIdMap = useMemo(() => {
+    const map = new Map<string, Widget>();
+    const traverse = (widgets: Widget[]) => {
+      for (const w of widgets) {
+        if (w.id !== GRID_ID) map.set(w.id, w);
+        if (w.children) traverse(w.children);
+      }
+    };
+    traverse(editorWidgets);
+    return map;
+  }, [editorWidgets]);
+
   const selectedWidgets: Widget[] = useMemo(
     () => getSelectedWidgets(editorWidgets, selectedWidgetIDs),
     [editorWidgets, selectedWidgetIDs],
@@ -1029,6 +1045,7 @@ export function useWidgetManager() {
     PVMap,
     macros,
     allWidgetIDs,
+    widgetIdMap,
     formatWdgToExport,
     fileLoadedTrig,
     pickedWidget,


### PR DESCRIPTION
Closes #143 

3 options were added: copy PV, value, and PV+Value
PV Name + Value also includes timestamp like the following:  `2026-06-12 22:01:17 demo:ai01 6887`

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/f4368dfe-df6b-4e03-8e4f-0661456f562f" />

Placeholder buttons for PV info (probe, coming soon) and PV History (future link with archiver) were also added as placeholders
