### PR TITLE
fix: treat grouped widgets as a single entity

### DIFF
--- a/src/components/GridZone/SelectionManager/SelectionManager.tsx
+++ b/src/components/GridZone/SelectionManager/SelectionManager.tsx
@@ -4,6 +4,7 @@
 import { FRONT_UI_ZIDX, GRID_ID } from "@src/constants/constants";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
+import { getTopLevelId } from "@src/context/widgetHelpers";
 import React, { useRef, useState, useEffect } from "react";
 
 interface SelectionManagerProps {
@@ -90,9 +91,13 @@ const SelectionManager: React.FC<SelectionManagerProps> = ({ gridRef, zoom, pan 
           return;
         }
         if (e.ctrlKey) {
-          setSelectedWidgetIDs((prev) =>
-            prev.includes(wId) ? prev.filter((pid) => pid !== wId) : [...prev, wId],
-          );
+          const effectiveId = getTopLevelId(editorWidgets, wId);
+          setSelectedWidgetIDs((prev) => {
+            const sanitized = prev.map((id) => getTopLevelId(editorWidgets, id));
+            return sanitized.includes(effectiveId)
+              ? sanitized.filter((pid) => pid !== effectiveId)
+              : [...sanitized, effectiveId];
+          });
         } else if (!selectedWidgetIDs.includes(wId)) {
           setSelectedWidgetIDs([wId]);
         }

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -231,7 +231,6 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
   const renderSelectionGroup = () => {
     if (!selectionBounds || selectedWidgetIDs.length <= 1) return null;
 
-    const selectedWidgets = editorWidgets.filter((w) => selectedWidgetIDs.includes(w.id));
     const canDrag = inEditMode && !isPanning;
     const canResize = inEditMode && !isPanning;
 

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -94,7 +94,9 @@ export function useWidgetManager() {
 
   const computeGroupBounds = useCallback(
     (widgetIds: string[]): DOMRectLike | null => {
-      const widgets = editorWidgets.filter((w) => widgetIds.includes(w.id));
+      const widgets = widgetIds
+        .map((id) => widgetIdMap.get(id))
+        .filter((w): w is Widget => w !== undefined);
       if (!widgets.length) return null;
 
       const xs = widgets.map((w) => w.editableProperties.x!.value);
@@ -107,7 +109,7 @@ export function useWidgetManager() {
       const maxY = Math.max(...ys.map((y, i) => y + hs[i]));
       return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
     },
-    [editorWidgets],
+    [widgetIdMap],
   );
 
   const selectionBounds = useMemo(

--- a/src/context/widgetHelpers.ts
+++ b/src/context/widgetHelpers.ts
@@ -119,6 +119,20 @@ export function getWidgetNested(widgets: Widget[], id: string): Widget | undefin
   return undefined;
 }
 
+/**
+ * Given a widget ID, return the ID of its top-level ancestor in the flat editorWidgets list.
+ * If the widget is already top-level, returns its own ID.
+ * This is used to ensure that selecting a child widget inside a group promotes the selection
+ * to the parent group, keeping the group intact during multi-select drag/resize.
+ */
+export function getTopLevelId(widgets: Widget[], id: string): string {
+  for (const w of widgets) {
+    if (w.id === id) return id;
+    if (w.children && getWidgetNested(w.children, id)) return w.id;
+  }
+  return id;
+}
+
 export function getSelectedWidgets(widgets: Widget[], selectedIds: string[]): Widget[] {
   const result: Widget[] = [];
   for (const w of widgets) {


### PR DESCRIPTION
If selecting individual widgets inside groups (for property editing), and adding an external one to the selection, some issues appeared:
- The grouped item became transparent (see [1]) for details;
- If dragging, the grouped item got moved as if it was not grouped;

This commit fixes both issues, and ensures the grouped widgets are always treated as a single instance during multi selections.

[1] - https://github.com/weiss-controls/weiss/issues/144