### PR TITLE
Widgets: add DisplayFormat property

### DIFF
--- a/src/components/Widgets/BitIndicator/BitIndicator.ts
+++ b/src/components/Widgets/BitIndicator/BitIndicator.ts
@@ -28,6 +28,7 @@ export const BitIndicator: WidgetDefinition = {
     useStringVal: PROPERTY_SCHEMAS.useStringVal,
     offLabel: PROPERTY_SCHEMAS.offLabel,
     onLabel: PROPERTY_SCHEMAS.onLabel,
+    displayFormat: PROPERTY_SCHEMAS.displayFormat,
     ...FILTERED_TEXT_PROPS,
   },
 };

--- a/src/components/Widgets/BitIndicator/BitIndicatorComp.tsx
+++ b/src/components/Widgets/BitIndicator/BitIndicatorComp.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import AlarmBorder from "@components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
+import { formatDisplayValue } from "@src/utils/displayFormat";
 
 const BitIndicatorComp: React.FC<WidgetUpdate> = ({ data }) => {
   const p = data.editableProperties;
@@ -21,7 +22,8 @@ const BitIndicatorComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const useStr = p.useStringVal?.value;
   const enumOption = canBeEnum && pvData?.enumChoices ? pvData?.enumChoices[value] : "";
-  const pvText = useStr ? (enumOption ?? "") : ((value as string) ?? "");
+  const displayFormat = p.displayFormat?.value ?? "Default";
+  const pvText = useStr ? (enumOption ?? "") : formatDisplayValue(value, displayFormat);
 
   const labelFromPV = p.labelFromPV?.value;
   const offLabel = p.offLabel?.value ?? "";

--- a/src/components/Widgets/InputField/InputField.ts
+++ b/src/components/Widgets/InputField/InputField.ts
@@ -20,6 +20,7 @@ export const InputField: WidgetDefinition = {
     unitsFromPV: PROPERTY_SCHEMAS.unitsFromPV,
     units: PROPERTY_SCHEMAS.units,
     disabled: PROPERTY_SCHEMAS.disabled,
+    displayFormat: PROPERTY_SCHEMAS.displayFormat,
     ...COMMON_PROPS,
     backgroundColor: { ...PROPERTY_SCHEMAS.backgroundColor, value: COLORS.inputColor },
     ...FILTERED_TEXT_PROPS,

--- a/src/components/Widgets/InputField/InputFieldComp.tsx
+++ b/src/components/Widgets/InputField/InputFieldComp.tsx
@@ -7,6 +7,7 @@ import type { WidgetUpdate } from "@src/types/widgets";
 import AlarmBorder from "@components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWSActionsContext } from "@src/context/useEpicsWSContext";
+import { formatDisplayValue } from "@src/utils/displayFormat";
 
 const InputFieldComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { writePVValue } = useWSActionsContext();
@@ -18,6 +19,7 @@ const InputFieldComp: React.FC<WidgetUpdate> = ({ data }) => {
   const pvData = data.pvData;
   const units =
     p.unitsFromPV?.value && pvData?.display?.units ? pvData.display.units : p.units?.value;
+  const displayFormat = p.displayFormat?.value ?? "Default";
 
   useEffect(() => {
     if (inEditMode) setInputValue("");
@@ -64,7 +66,7 @@ const InputFieldComp: React.FC<WidgetUpdate> = ({ data }) => {
             isFocused
               ? inputValue
               : !inEditMode && pvData?.value !== undefined
-                ? String(pvData.value) + (units ? ` ${units}` : "")
+                ? formatDisplayValue(pvData.value, displayFormat) + (units ? ` ${units}` : "")
                 : inputValue
           }
           onFocus={() => {

--- a/src/components/Widgets/MultiBitIndicator/MultiBitIndicator.ts
+++ b/src/components/Widgets/MultiBitIndicator/MultiBitIndicator.ts
@@ -27,5 +27,6 @@ export const MultiBitIndicator: WidgetDefinition = {
     spacing: PROPERTY_SCHEMAS.spacing,
     pvName: PROPERTY_SCHEMAS.pvName,
     alarmBorder: PROPERTY_SCHEMAS.alarmBorder,
+    displayFormat: PROPERTY_SCHEMAS.displayFormat,
   },
 };

--- a/src/components/Widgets/ProgressBar/ProgressBar.ts
+++ b/src/components/Widgets/ProgressBar/ProgressBar.ts
@@ -21,6 +21,7 @@ export const ProgressBar: WidgetDefinition = {
     horizontal: PROPERTY_SCHEMAS.horizontal,
     showValue: PROPERTY_SCHEMAS.showValue,
     valuePlcmnt: PROPERTY_SCHEMAS.valuePlcmnt,
+    displayFormat: PROPERTY_SCHEMAS.displayFormat,
     showPercentage: PROPERTY_SCHEMAS.showPercentage,
     barColor: PROPERTY_SCHEMAS.barColor,
     ...TEXT_PROPS,

--- a/src/components/Widgets/Slider/Slider.ts
+++ b/src/components/Widgets/Slider/Slider.ts
@@ -26,5 +26,6 @@ export const Slider: WidgetDefinition = {
     limitsFromPV: PROPERTY_SCHEMAS.limitsFromPV,
     stepSize: PROPERTY_SCHEMAS.stepSize,
     horizontal: PROPERTY_SCHEMAS.horizontal,
+    displayFormat: PROPERTY_SCHEMAS.displayFormat,
   },
 };

--- a/src/components/Widgets/Slider/SliderComp.tsx
+++ b/src/components/Widgets/Slider/SliderComp.tsx
@@ -7,6 +7,7 @@ import type { WidgetUpdate } from "@src/types/widgets";
 import AlarmBorder from "@components/AlarmBorder/AlarmBorder";
 import { useWSActionsContext } from "@src/context/useEpicsWSContext";
 import { useUIContext } from "@src/context/useUIContext";
+import { formatDisplayValue } from "@src/utils/displayFormat";
 
 const SliderComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { writePVValue } = useWSActionsContext();
@@ -24,6 +25,7 @@ const SliderComp: React.FC<WidgetUpdate> = ({ data }) => {
   const value = inEditMode ? 0 : runtimeVal;
   const isHorizontal = p.horizontal?.value ?? true;
   const orientation = isHorizontal ? "horizontal" : "vertical";
+  const displayFormat = p.displayFormat?.value ?? "Default";
 
   const handleChange = (_: Event | React.SyntheticEvent<Element, Event>, newValue: number) => {
     if (!inEditMode && p.pvName?.value && typeof newValue === "number") {
@@ -59,6 +61,8 @@ const SliderComp: React.FC<WidgetUpdate> = ({ data }) => {
           step={step}
           marks={step !== undefined}
           disabled={p.disabled?.value}
+          valueLabelDisplay="auto"
+          valueLabelFormat={(v) => formatDisplayValue(v, displayFormat)}
           onChange={handleChange}
           sx={{
             color: p.backgroundColor?.value ?? "primary.main",

--- a/src/components/Widgets/TextUpdate/TextUpdate.ts
+++ b/src/components/Widgets/TextUpdate/TextUpdate.ts
@@ -24,5 +24,6 @@ export const TextUpdate: WidgetDefinition = {
     units: PROPERTY_SCHEMAS.units,
     precisionFromPV: PROPERTY_SCHEMAS.precisionFromPV,
     precision: PROPERTY_SCHEMAS.precision,
+    displayFormat: PROPERTY_SCHEMAS.displayFormat,
   },
 };

--- a/src/components/Widgets/TextUpdate/TextUpdateComp.tsx
+++ b/src/components/Widgets/TextUpdate/TextUpdateComp.tsx
@@ -6,6 +6,7 @@ import type { WidgetUpdate } from "@src/types/widgets";
 import { FLEX_ALIGN_MAP } from "@src/constants/constants";
 import AlarmBorder from "@components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
+import { formatDisplayValue } from "@src/utils/displayFormat";
 
 const TextUpdateComp: React.FC<WidgetUpdate> = ({ data }) => {
   const p = data.editableProperties;
@@ -16,19 +17,26 @@ const TextUpdateComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const units = p.unitsFromPV?.value ? pvData?.display?.units : p.units?.value;
   const precision = p.precisionFromPV?.value ? pvData?.display?.precision : p.precision?.value;
+  const displayFormat = p.displayFormat?.value ?? "Default";
 
-  let displayValue = pvData?.value;
+  let displayValue: string;
 
-  if (!inEditMode && typeof pvData?.value === "number") {
-    const val = pvData.value;
-    if (typeof precision === "number" && precision > 0 && !pvData.enumChoices) {
-      displayValue = val.toFixed(precision);
-    } else if (pvData.enumChoices && pvData.enumChoices.length > 0) {
-      const validIdx = val <= pvData.enumChoices.length;
-      displayValue = validIdx ? pvData.enumChoices[val] : val;
-    }
-  } else if (inEditMode) {
+  if (inEditMode) {
     displayValue = p.pvName?.value ?? p.label?.value ?? "";
+  } else {
+    const val = pvData?.value;
+    if (val === undefined || val === null) {
+      displayValue = "";
+    } else if (
+      typeof val === "number" &&
+      pvData?.enumChoices?.length &&
+      (displayFormat === "Default" || displayFormat === "String")
+    ) {
+      const label = val < pvData.enumChoices.length ? pvData.enumChoices[val] : undefined;
+      displayValue = label ?? formatDisplayValue(val, displayFormat, precision);
+    } else {
+      displayValue = formatDisplayValue(val, displayFormat, precision);
+    }
   }
 
   return (

--- a/src/types/widgetProperties.ts
+++ b/src/types/widgetProperties.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import type { WidgetProperty, PropertyValue, WidgetProperties } from "./widgets";
+import {
+  type WidgetProperty,
+  type PropertyValue,
+  type WidgetProperties,
+  type ValueDisplayFormat,
+  valueDisplayFormats,
+} from "./widgets";
 import { COLORS } from "@src/constants/constants";
 
 /**
@@ -30,9 +36,10 @@ export const PROPERTY_SCHEMAS = {
   y:               defineProp({ selType: "number", label: "Y", value: 100 as number, category: "Layout" }),
   width:           defineProp({ selType: "number", label: "Width", value: 100 as number, limits: { min: 1 }, category: "Layout" }),
   height:          defineProp({ selType: "number", label: "Height", value: 40 as number, limits: { min: 1 }, category: "Layout" }),
-  label:           defineProp({ selType: "text", label: "Label", value: "" as string, category: "Text" }),
+  label:           defineProp({ selType: "text", label: "Label", value: "" as string, category: "Text" }),  
   tooltip:         defineProp({ selType: "text", label: "Tooltip", value: "$(pvname) - $(pvdesc)" as string, category: "Text" }),
   visible:         defineProp({ selType: "none", label: "Visible", value: true as boolean, category: "Layout" }),
+  displayFormat:   defineProp({ selType: "select", label: "Display Format", value: "Default" as ValueDisplayFormat, options: [...valueDisplayFormats], category: "Layout" }),
   // Style
   backgroundColor: defineProp({ selType: "colorSel", label: "Background Color", value: COLORS.backgroundColor, category: "Style" }),
   borderColor:     defineProp({ selType: "colorSel", label: "Border Color", value: COLORS.textColor, category: "Style" }),

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -33,6 +33,18 @@ export type PropertySelectorType =
 /** Allowed values for a widget property */
 export type PropertyValue = string | number | boolean | string[] | Record<string, string>;
 
+export const valueDisplayFormats = [
+  "Default",
+  "String",
+  "Hexadecimal",
+  "Scientific",
+  "Engineering",
+  "Timestamp",
+];
+
+/** Display formats allowed to be applied to values */
+export type ValueDisplayFormat = (typeof valueDisplayFormats)[number];
+
 /** Format of numerical limits for a property */
 export interface PropertyLimits {
   min?: number;

--- a/src/utils/displayFormat.ts
+++ b/src/utils/displayFormat.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import type { PVValue } from "@src/types/epicsWS";
+import type { ValueDisplayFormat } from "@src/types/widgets";
+
+function toEngineeringNotation(value: number, precision?: number): string {
+  if (value === 0) return "0";
+  const sign = value < 0 ? "-" : "";
+  const abs = Math.abs(value);
+  const exp = Math.floor(Math.log10(abs));
+  const engExp = Math.floor(exp / 3) * 3;
+  const mantissa = abs / Math.pow(10, engExp);
+  const formatted =
+    precision !== undefined
+      ? mantissa.toFixed(precision)
+      : parseFloat(mantissa.toPrecision(4)).toString();
+  const expStr = engExp >= 0 ? `e+${engExp}` : `e${engExp}`;
+  return `${sign}${formatted}${expStr}`;
+}
+
+/**
+ * Formats a PV value according to the specified display format.
+ * @param value - The raw PV value to format.
+ * @param format - The display format to apply.
+ * @param precision - Optional decimal precision for numeric formats.
+ */
+export function formatDisplayValue(
+  value: PVValue,
+  format: ValueDisplayFormat,
+  precision?: number,
+): string {
+  if (value === undefined || value === null) return "";
+
+  switch (format) {
+    case "String":
+      if (Array.isArray(value) && value.every((v) => typeof v === "number")) {
+        // Int8 char-code array to string; strip null terminator
+        return String.fromCharCode(...value.filter((c) => c !== 0));
+      }
+      return String(value);
+
+    case "Hexadecimal": {
+      const num = Number(value);
+      if (isNaN(num)) return String(value);
+      return `0x${Math.trunc(num).toString(16).toUpperCase()}`;
+    }
+
+    case "Scientific": {
+      const num = Number(value);
+      if (isNaN(num)) return String(value);
+      return precision !== undefined ? num.toExponential(precision) : num.toExponential();
+    }
+
+    case "Engineering": {
+      const num = Number(value);
+      if (isNaN(num)) return String(value);
+      return toEngineeringNotation(num, precision);
+    }
+
+    case "Timestamp": {
+      const num = Number(value);
+      if (isNaN(num)) return String(value);
+      return new Date(num * 1000).toLocaleString();
+    }
+
+    case "Default":
+    default: {
+      if (typeof value === "number") {
+        return precision !== undefined ? value.toFixed(precision) : String(value);
+      }
+      return String(value);
+    }
+  }
+}


### PR DESCRIPTION
- Closes #145
Widgets that can display PV values now have "Display format" property available:
<img width="364" height="312" alt="image" src="https://github.com/user-attachments/assets/f3a9acc0-74b8-4095-a5e8-a64ca49a0c75" />
