### PR TITLE
cleanup: redesign handling of macro substitutions

### DIFF
--- a/src/components/AlarmPanel/AlarmPanel.tsx
+++ b/src/components/AlarmPanel/AlarmPanel.tsx
@@ -21,7 +21,6 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import { COLORS } from "@src/constants/constants";
 import type { PVData } from "@src/types/epicsWS";
-import { useWidgetContext } from "@src/context/useWidgetContext";
 
 const SEVERITY_LABELS: Record<number, string> = {
   0: "NO_ALARM",
@@ -54,14 +53,12 @@ type SeverityFilter = "all" | "minor" | "major" | "invalid";
 export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) {
   const [search, setSearch] = useState("");
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
-  const { PVMap } = useWidgetContext();
-
   // Collect all PVs in alarm
   const alarmPVs = useMemo(() => {
     return Object.entries(pvState)
       .filter(([, data]) => data.alarm && data.alarm.severity > 0)
       .map(([, data]) => ({
-        pv: PVMap.get(data.pv) ?? data.pv,
+        pv: data.pv,
         value: data.value,
         severity: data.alarm?.severity ?? 0,
         message: data.alarm?.message ?? "",
@@ -70,7 +67,7 @@ export default function AlarmPanel({ open, onClose, pvState }: AlarmPanelProps) 
         precision: data.display?.precision,
       }))
       .sort((a, b) => b.severity - a.severity || a.pv.localeCompare(b.pv));
-  }, [pvState, PVMap]);
+  }, [pvState]);
 
   // Apply filters
   const filteredPVs = useMemo(() => {

--- a/src/components/GridZone/GridZoneComp.tsx
+++ b/src/components/GridZone/GridZoneComp.tsx
@@ -64,7 +64,6 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     groupSelected,
     ungroupSelected,
     moveSelected,
-    PVMap,
     widgetIdMap,
   } = useWidgetContext();
 
@@ -252,11 +251,10 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
       while (el && el !== document.body) {
         const widget = widgetIdMap.get(el.id);
         if (widget) {
-          const rawPvName = widget.editableProperties.pvName?.value;
-          if (rawPvName) {
-            const substituted = PVMap.get(rawPvName) ?? rawPvName;
-            foundPVName = substituted;
-            foundPVData = pvState[rawPvName] ?? null;
+          const runtimePVName = widget.runtimePVName ?? widget.editableProperties.pvName?.value;
+          if (runtimePVName) {
+            foundPVName = runtimePVName;
+            foundPVData = pvState[runtimePVName] ?? null;
           }
           break;
         }

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -3,7 +3,12 @@
 
 import React, { useEffect, useMemo, useRef, type ReactNode } from "react";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
-import type { Widget, MultiWidgetPropertyUpdates, DOMRectLike } from "@src/types/widgets";
+import type {
+  Widget,
+  MultiWidgetPropertyUpdates,
+  DOMRectLike,
+  WidgetProperties,
+} from "@src/types/widgets";
 import { Rnd, type DraggableData, type Position, type RndDragEvent } from "react-rnd";
 import { GRID_ID } from "@src/constants/constants";
 import "./WidgetRenderer.css";
@@ -40,6 +45,8 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
   // Refs to track previous pvState entries and previously computed Widget objects.
   const prevPVStateRef = useRef<Record<string, PVData>>({});
   const prevWidgetsMapRef = useRef<Map<string, Widget>>(new Map());
+  const prevRawPropsMapRef = useRef<Map<string, WidgetProperties>>(new Map());
+  const prevGridMacrosRef = useRef<Record<string, string>>({});
   const prevInEditModeRef = useRef(inEditMode);
 
   // Compute the merged globalMacros overrides produced by all widgets' rules.
@@ -76,17 +83,24 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
     const modeChanged = inEditMode !== prevInEditModeRef.current;
     prevInEditModeRef.current = inEditMode;
     const prevWidgetsMap = modeChanged ? new Map<string, Widget>() : prevWidgetsMapRef.current;
+    const prevRawPropsMap = modeChanged
+      ? new Map<string, WidgetProperties>()
+      : prevRawPropsMapRef.current;
 
     const ctx: MergeWidgetContext = {
       pvState,
       prevPVState: prevPVStateRef.current,
       prevWidgetsMap,
+      prevRawPropsMap,
       gridMacros,
+      prevGridMacros: prevGridMacrosRef.current,
       inEditMode,
     };
-    const { result, nextWidgetsMap } = computeWidgetsForRender(editorWidgets, ctx);
+    const { result, nextWidgetsMap, nextRawPropsMap } = computeWidgetsForRender(editorWidgets, ctx);
     prevPVStateRef.current = pvState;
     prevWidgetsMapRef.current = nextWidgetsMap;
+    prevRawPropsMapRef.current = nextRawPropsMap;
+    prevGridMacrosRef.current = gridMacros;
 
     return result;
   }, [editorWidgets, pvState, inEditMode, globalMacrosOverrides, baseGridMacros]);

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -44,7 +44,7 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
 
   // Compute the merged globalMacros overrides produced by all widgets' rules.
   // Separate from widgetsForRender so a useEffect can write the result back to context
-  // (to keep PVMap subscriptions current) without the state write happening inside a useMemo.
+  // (to keep subscriptions current) without the state write happening inside a useMemo.
   const baseGridMacros = useMemo(
     () => editorWidgets.find((w) => w.id === GRID_ID)?.editableProperties.macros?.value ?? {},
     [editorWidgets],
@@ -55,7 +55,7 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
     return computeGlobalMacrosOverrides(editorWidgets, pvState, baseGridMacros);
   }, [editorWidgets, pvState, inEditMode, baseGridMacros]);
 
-  // Write back globalMacros overrides to context (for PVMap subscriptions).
+  // Write back globalMacros overrides to context (to keep subscriptions current).
   // JSON.stringify guard prevents unnecessary state updates and infinite loops.
   const prevGlobalMacrosJsonRef = useRef<string>("");
   useEffect(() => {

--- a/src/components/WidgetRenderer/widgetRenderUtils.ts
+++ b/src/components/WidgetRenderer/widgetRenderUtils.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import type { Widget, Rule } from "@src/types/widgets";
+import type {
+  Widget,
+  Rule,
+  WidgetProperties,
+  WidgetProperty,
+  PropertyKey,
+} from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
 import { flattenWidgetTree } from "@src/context/widgetHelpers";
 import { buildInternalMacros, substituteInStr, substituteTextProps } from "@src/utils/macros";
@@ -49,7 +55,9 @@ export interface MergeWidgetContext {
   pvState: Record<string, PVData>;
   prevPVState: Record<string, PVData>;
   prevWidgetsMap: Map<string, Widget>;
+  prevRawPropsMap: Map<string, WidgetProperties>;
   gridMacros: Record<string, string>;
+  prevGridMacros: Record<string, string>;
   inEditMode: boolean;
 }
 
@@ -63,7 +71,7 @@ const getStableWidget = (
   ctx: MergeWidgetContext,
   newChildren: Widget[] | undefined,
 ): Widget | undefined => {
-  const { pvState, prevPVState, prevWidgetsMap, gridMacros } = ctx;
+  const { pvState, prevPVState, prevWidgetsMap, prevRawPropsMap, gridMacros, prevGridMacros } = ctx;
   const pvName = w.runtimePVName;
   const pvNames = w.runtimePVNames;
 
@@ -87,9 +95,15 @@ const getStableWidget = (
     !newChildren || newChildren.every((c, i) => c === prevWidgetsMap.get(w.children![i].id));
 
   const prevWidget = prevWidgetsMap.get(w.id);
-  const structureStable = prevWidget?.editableProperties === w.editableProperties;
+  // Compare raw-to-raw: prevRawPropsMap holds the unsubstituted editableProperties from
+  // the previous render, so this is not affected by substituteTextProps creating new objects.
+  const structureStable = prevRawPropsMap.get(w.id) === w.editableProperties;
+  // If gridMacros changed (e.g. a rule updated a globalMacro like $(IDX)), any widget
+  // whose text props reference that macro must be recomputed even if its own PV and
+  // raw props are unchanged.
+  const macrosStable = gridMacros === prevGridMacros;
 
-  return ownPVsStable && childrenStable && structureStable ? prevWidget : undefined;
+  return ownPVsStable && childrenStable && structureStable && macrosStable ? prevWidget : undefined;
 };
 
 /**
@@ -100,13 +114,19 @@ const getStableWidget = (
 export function computeWidgetsForRender(
   editorWidgets: Widget[],
   ctx: MergeWidgetContext,
-): { result: Widget[]; nextWidgetsMap: Map<string, Widget> } {
-  const { pvState, gridMacros, inEditMode } = ctx;
+): {
+  result: Widget[];
+  nextWidgetsMap: Map<string, Widget>;
+  nextRawPropsMap: Map<string, WidgetProperties>;
+} {
+  const { pvState, gridMacros, inEditMode, prevWidgetsMap } = ctx;
   const nextWidgetsMap = new Map<string, Widget>();
+  const nextRawPropsMap = new Map<string, WidgetProperties>();
 
   const mergeWidget = (w: Widget): Widget => {
     if (inEditMode) {
       nextWidgetsMap.set(w.id, w);
+      nextRawPropsMap.set(w.id, w.editableProperties);
       return w;
     }
     const pvName = w.runtimePVName;
@@ -118,6 +138,7 @@ export function computeWidgetsForRender(
     const stableWidget = getStableWidget(w, ctx, newChildren);
     if (stableWidget) {
       nextWidgetsMap.set(w.id, stableWidget);
+      nextRawPropsMap.set(w.id, w.editableProperties);
       return stableWidget;
     }
 
@@ -157,10 +178,54 @@ export function computeWidgetsForRender(
     const internalMacros = buildInternalMacros(effectivePvName, pvData);
     const allMacros =
       Object.keys(internalMacros).length > 0 ? { ...gridMacros, ...internalMacros } : gridMacros;
-    const mergedWithMacros: Widget = {
-      ...merged,
-      editableProperties: substituteTextProps(merged.editableProperties, allMacros),
-    };
+
+    // Substitute macros in text properties, then stabilise the reference.
+    //
+    // For each prop where the reference changed, compare the substituted value against
+    // the previous substituted value.  If the value is identical (same string / same array
+    // elements), reuse the previous prop object so the reference stays stable.
+    const prevSubstitutedProps = prevWidgetsMap.get(w.id)?.editableProperties;
+    const freshSubstitutedProps = substituteTextProps(merged.editableProperties, allMacros);
+
+    let substitutedProps: WidgetProperties;
+    if (!prevSubstitutedProps || freshSubstitutedProps === merged.editableProperties) {
+      // No previous state, or nothing was substituted: use as-is.
+      substitutedProps = freshSubstitutedProps;
+    } else {
+      type PropsRecord = Record<PropertyKey, WidgetProperty>;
+      const freshRec = freshSubstitutedProps as PropsRecord;
+      const prevRec = prevSubstitutedProps as PropsRecord;
+      const stabilized: PropsRecord = { ...freshRec };
+      let anyRealChange = false;
+      for (const k of Object.keys(freshRec) as PropertyKey[]) {
+        const fp = freshRec[k];
+        const pp = prevRec[k];
+        if (fp === pp) continue; // reference already stable
+        const fv = fp?.value;
+        const pv = pp?.value;
+        if (fv === pv) {
+          // Same primitive value: reuse previous prop object.
+          stabilized[k] = pp;
+        } else if (
+          Array.isArray(fv) &&
+          Array.isArray(pv) &&
+          fv.length === pv.length &&
+          fv.every((x, i) => x === pv[i])
+        ) {
+          // Same array contents: reuse previous prop object.
+          stabilized[k] = pp;
+        } else {
+          anyRealChange = true;
+        }
+      }
+      // If all values were identical, return the exact previous container object so
+      // that stability checks on editableProperties in downstream components pass.
+      substitutedProps = anyRealChange
+        ? (stabilized as unknown as WidgetProperties)
+        : prevSubstitutedProps;
+    }
+
+    const mergedWithMacros: Widget = { ...merged, editableProperties: substitutedProps };
 
     // Apply per-widget rule overrides to editableProperties:
     // - globalMacros: consumed by computeGlobalMacrosOverrides, not applied here.
@@ -196,9 +261,10 @@ export function computeWidgetsForRender(
       : mergedWithMacros;
 
     nextWidgetsMap.set(w.id, withRules);
+    nextRawPropsMap.set(w.id, w.editableProperties);
     return withRules;
   };
 
   const result = editorWidgets.map(mergeWidget);
-  return { result, nextWidgetsMap };
+  return { result, nextWidgetsMap, nextRawPropsMap };
 }

--- a/src/components/WidgetRenderer/widgetRenderUtils.ts
+++ b/src/components/WidgetRenderer/widgetRenderUtils.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import type { Widget } from "@src/types/widgets";
+import type { Widget, Rule } from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
 import { flattenWidgetTree } from "@src/context/widgetHelpers";
 import { buildInternalMacros, substituteInStr, substituteTextProps } from "@src/utils/macros";
@@ -28,12 +28,9 @@ export function computeGlobalMacrosOverrides(
   let merged: Record<string, string> = {};
   for (const w of flattenWidgetTree(widgets)) {
     if (!w.rules?.length) continue;
-    const wPvName = w.editableProperties.pvName?.value;
+    const wPvName = w.runtimePVName;
     const wPvData = wPvName ? pvState[wPvName] : undefined;
-    const wInternalMacros = buildInternalMacros(
-      wPvName ? substituteInStr(wPvName, baseGridMacros) : undefined,
-      wPvData,
-    );
+    const wInternalMacros = buildInternalMacros(wPvName, wPvData);
     const wMacros =
       Object.keys(wInternalMacros).length > 0
         ? { ...baseGridMacros, ...wInternalMacros }
@@ -57,6 +54,45 @@ export interface MergeWidgetContext {
 }
 
 /**
+ * Returns the previously cached `Widget` if nothing relevant changed (PV data,
+ * children, own property structure), or `undefined` if the widget needs to be
+ * recomputed.
+ */
+const getStableWidget = (
+  w: Widget,
+  ctx: MergeWidgetContext,
+  newChildren: Widget[] | undefined,
+): Widget | undefined => {
+  const { pvState, prevPVState, prevWidgetsMap, gridMacros } = ctx;
+  const pvName = w.runtimePVName;
+  const pvNames = w.runtimePVNames;
+
+  const ruleConditionPVsStable = (r: Rule) =>
+    r.pvNames.every((pv: string) => {
+      const resolved = substituteInStr(pv, gridMacros);
+      return pvState[resolved] === prevPVState[resolved];
+    });
+  const ruleActionPVStable = (r: Rule) => {
+    const actionPV = r.actions?.pvName;
+    return typeof actionPV !== "string" || !actionPV || pvState[actionPV] === prevPVState[actionPV];
+  };
+
+  const rulePVsStable =
+    !w.rules?.length || w.rules.every((r) => ruleConditionPVsStable(r) && ruleActionPVStable(r));
+  const ownPVsStable =
+    (!pvName || pvState[pvName] === prevPVState[pvName]) &&
+    (!pvNames?.length || pvNames.every((pv) => pvState[pv] === prevPVState[pv])) &&
+    rulePVsStable;
+  const childrenStable =
+    !newChildren || newChildren.every((c, i) => c === prevWidgetsMap.get(w.children![i].id));
+
+  const prevWidget = prevWidgetsMap.get(w.id);
+  const structureStable = prevWidget?.editableProperties === w.editableProperties;
+
+  return ownPVsStable && childrenStable && structureStable ? prevWidget : undefined;
+};
+
+/**
  * Merges PV data, macro substitutions, and rule overrides into every widget
  * in `editorWidgets`.  Returns the merged array and the new widget cache map
  * that should be stored back to `prevWidgetsMapRef` by the caller.
@@ -65,7 +101,7 @@ export function computeWidgetsForRender(
   editorWidgets: Widget[],
   ctx: MergeWidgetContext,
 ): { result: Widget[]; nextWidgetsMap: Map<string, Widget> } {
-  const { pvState, prevPVState, prevWidgetsMap, gridMacros, inEditMode } = ctx;
+  const { pvState, gridMacros, inEditMode } = ctx;
   const nextWidgetsMap = new Map<string, Widget>();
 
   const mergeWidget = (w: Widget): Widget => {
@@ -73,46 +109,21 @@ export function computeWidgetsForRender(
       nextWidgetsMap.set(w.id, w);
       return w;
     }
-
-    const pvName = w.editableProperties.pvName?.value;
-    const pvNames = w.editableProperties.pvNames?.value;
+    const pvName = w.runtimePVName;
+    const pvNames = w.runtimePVNames;
 
     // Process children first so we can check child stability for the parent decision.
     const newChildren = w.children?.map(mergeWidget);
 
-    // Check if PV data changed for this widget's own PVs and rule PVs.
-    const rulePVsStable =
-      !w.rules?.length ||
-      w.rules.every(
-        (r) =>
-          r.pvNames.every((pv) => pvState[pv] === prevPVState[pv]) &&
-          (typeof r.actions?.pvName !== "string" ||
-            !r.actions.pvName ||
-            pvState[r.actions.pvName] === prevPVState[r.actions.pvName]),
-      );
-    const ownPVsStable =
-      (!pvName || pvState[pvName] === prevPVState[pvName]) &&
-      (!pvNames?.length || pvNames.every((pv) => pvState[pv] === prevPVState[pv])) &&
-      rulePVsStable;
-
-    const childrenStable =
-      !newChildren || newChildren.every((c, i) => c === prevWidgetsMap.get(w.children![i].id));
-
-    // Check if the widget's own property structure changed.
-    const prevWidget = prevWidgetsMap.get(w.id);
-    const structureStable = prevWidget?.editableProperties === w.editableProperties;
-
-    if (ownPVsStable && childrenStable && structureStable) {
-      nextWidgetsMap.set(w.id, prevWidget);
-      return prevWidget;
+    const stableWidget = getStableWidget(w, ctx, newChildren);
+    if (stableWidget) {
+      nextWidgetsMap.set(w.id, stableWidget);
+      return stableWidget;
     }
 
-    // Evaluate rules with the original pvName data so $(pvvalue) works in action values.
+    // Evaluate rules using the widget's resolved PV name so $(pvvalue) works in action values.
     const origPvData = pvName ? pvState[pvName] : undefined;
-    const origInternalMacros = buildInternalMacros(
-      pvName ? substituteInStr(pvName, gridMacros) : undefined,
-      origPvData,
-    );
+    const origInternalMacros = buildInternalMacros(pvName, origPvData);
     const origAllMacros =
       Object.keys(origInternalMacros).length > 0
         ? { ...gridMacros, ...origInternalMacros }
@@ -120,7 +131,7 @@ export function computeWidgetsForRender(
     const ruleEvalMacros = pvName ? { ...origAllMacros, "$(pvname)": pvName } : origAllMacros;
     const ruleOverrides = evaluateRules(w.rules ?? [], pvState, ruleEvalMacros);
 
-    // Derive effective pvName from rule override (if any).
+    // Derive effective pvName from rule override (if any); it is already resolved.
     const effectivePvName =
       typeof ruleOverrides.pvName === "string" && ruleOverrides.pvName
         ? ruleOverrides.pvName
@@ -135,19 +146,15 @@ export function computeWidgetsForRender(
     }
     if (pvNames?.length) {
       multiPvData = {};
-      for (const pv of pvNames) {
-        const d = pvState[pv];
-        if (d) multiPvData[substituteInStr(pv, gridMacros)] = d;
+      for (const resolved of pvNames) {
+        const d = pvState[resolved];
+        if (d) multiPvData[resolved] = d;
       }
     }
 
-    // Rebuild internal macros from effective pvName + effective pvData, then
-    // apply macro substitution across all text properties.
+    // Build internal macros from effective pvName (already resolved) + pvData.
     const merged: Widget = { ...w, pvData, multiPvData, children: newChildren };
-    const internalMacros = buildInternalMacros(
-      effectivePvName ? substituteInStr(effectivePvName, gridMacros) : undefined,
-      pvData,
-    );
+    const internalMacros = buildInternalMacros(effectivePvName, pvData);
     const allMacros =
       Object.keys(internalMacros).length > 0 ? { ...gridMacros, ...internalMacros } : gridMacros;
     const mergedWithMacros: Widget = {

--- a/src/components/Widgets/ActionButton/ActionButtonComp.tsx
+++ b/src/components/Widgets/ActionButton/ActionButtonComp.tsx
@@ -13,10 +13,11 @@ const ActionButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { writePVValue } = useWSActionsContext();
   const { inEditMode } = useUIContext();
   const p = data.editableProperties;
+  const runtimePVName = data.runtimePVName;
   const pvData = data.pvData;
 
   const handleClick = (_e: React.MouseEvent) => {
-    if (!inEditMode) {
+    if (!inEditMode && runtimePVName) {
       if (p.pvName?.value && p.actionValue?.value !== undefined) {
         const actionValue = p.actionValue.value;
         // convert to number if is number as string
@@ -24,7 +25,7 @@ const ActionButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
           typeof actionValue === "string" && !isNaN(Number(actionValue))
             ? Number(actionValue)
             : actionValue;
-        writePVValue(p.pvName.value, value);
+        writePVValue(runtimePVName, value);
       }
     }
   };

--- a/src/components/Widgets/InputField/InputFieldComp.tsx
+++ b/src/components/Widgets/InputField/InputFieldComp.tsx
@@ -16,6 +16,7 @@ const InputFieldComp: React.FC<WidgetUpdate> = ({ data }) => {
   const [isFocused, setIsFocused] = useState(false);
 
   const p = data.editableProperties;
+  const runtimePVName = data.runtimePVName;
   const pvData = data.pvData;
   const units =
     p.unitsFromPV?.value && pvData?.display?.units ? pvData.display.units : p.units?.value;
@@ -28,9 +29,9 @@ const InputFieldComp: React.FC<WidgetUpdate> = ({ data }) => {
   if (!p.visible?.value) return null;
 
   const handleWrite = (value: number | string) => {
-    if (inEditMode) return;
+    if (inEditMode || !runtimePVName) return;
     if (p.pvName?.value) {
-      writePVValue(p.pvName.value, value);
+      writePVValue(runtimePVName, value);
     }
   };
 

--- a/src/components/Widgets/Slider/SliderComp.tsx
+++ b/src/components/Widgets/Slider/SliderComp.tsx
@@ -13,6 +13,7 @@ const SliderComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { writePVValue } = useWSActionsContext();
   const { inEditMode } = useUIContext();
   const p = data.editableProperties;
+  const runtimePVName = data.runtimePVName;
   const pvData = data.pvData;
   if (!p.visible?.value) return null;
 
@@ -28,8 +29,8 @@ const SliderComp: React.FC<WidgetUpdate> = ({ data }) => {
   const displayFormat = p.displayFormat?.value ?? "Default";
 
   const handleChange = (_: Event | React.SyntheticEvent<Element, Event>, newValue: number) => {
-    if (!inEditMode && p.pvName?.value && typeof newValue === "number") {
-      writePVValue(p.pvName.value, newValue);
+    if (!inEditMode && runtimePVName && typeof newValue === "number") {
+      writePVValue(runtimePVName, newValue);
     }
   };
 

--- a/src/components/Widgets/Spinner/SpinnerComp.tsx
+++ b/src/components/Widgets/Spinner/SpinnerComp.tsx
@@ -26,6 +26,7 @@ const SpinnerComp: React.FC<WidgetUpdate> = ({ data }) => {
   const id = React.useId();
 
   const p = data.editableProperties;
+  const runtimePVName = data.runtimePVName;
   const pvData = data.pvData;
   const units =
     p.unitsFromPV?.value && pvData?.display?.units ? pvData.display.units : p.units?.value;
@@ -65,10 +66,8 @@ const SpinnerComp: React.FC<WidgetUpdate> = ({ data }) => {
   if (!p.visible?.value) return null;
 
   const handleWrite = (value: number | null) => {
-    if (inEditMode || value === null) return;
-    if (p.pvName?.value) {
-      writePVValue(p.pvName.value, value);
-    }
+    if (inEditMode || value === null || !runtimePVName) return;
+    writePVValue(runtimePVName, value);
   };
 
   return (

--- a/src/components/Widgets/ToggleButton/ToggleButtonComp.tsx
+++ b/src/components/Widgets/ToggleButton/ToggleButtonComp.tsx
@@ -13,6 +13,7 @@ const ToggleButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { writePVValue } = useWSActionsContext();
   const { inEditMode } = useUIContext();
   const p = data.editableProperties;
+  const runtimePVName = data.runtimePVName;
   const pvData = data.pvData;
   const value = pvData?.value;
   const validValue = value === 1 || value === 0;
@@ -37,8 +38,8 @@ const ToggleButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
   }
 
   const handleClick = (_e: React.MouseEvent) => {
-    if (!inEditMode && validValue && p.pvName?.value) {
-      writePVValue(p.pvName.value, Number(!value));
+    if (!inEditMode && validValue && runtimePVName) {
+      writePVValue(runtimePVName, Number(!value));
     }
   };
 

--- a/src/context/ContextProvider.tsx
+++ b/src/context/ContextProvider.tsx
@@ -10,7 +10,7 @@ import { useWidgetManager } from "./useWidgetManager";
 
 export const ContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const widgetManager = useWidgetManager();
-  const ws = useEpicsWS(widgetManager.PVMap);
+  const ws = useEpicsWS(widgetManager.resolvedPVList);
   const ui = useUIManager(
     ws,
     widgetManager.setSelectedWidgetIDs,

--- a/src/context/useEpicsWS.ts
+++ b/src/context/useEpicsWS.ts
@@ -1,91 +1,56 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { WSClient } from "@src/services/WSClient/WSClient";
 import type { PVData, PVValue, WSMessage } from "@src/types/epicsWS";
-import type { useWidgetManager } from "./useWidgetManager";
 import { WS_URL } from "@src/constants/constants";
 
 /**
  * Hook that manages a WebSocket session to the PV WebSocket.
  *
- * - Handles subscribing/unsubscribing PVs (using resolved names)
+ * - Handles subscribing/unsubscribing resolved PV names
  * - Caches metadata
- * - Forwards updates mapped back to widget PV names
+ * - Stores pvState keyed by resolved PV name
  *
- * @param PVMap Map of widget PV names (may contain macros) to resolved PV names
+ * @param resolvedPVList  Flat deduplicated list of all resolved PV names to subscribe to
  */
-export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["PVMap"]) {
+export default function useEpicsWS(resolvedPVList: string[]) {
   /** WebSocket client instance */
   const ws = useRef<WSClient | null>(null);
   const [wsConnected, setWSConnected] = useState(false);
+  /** Per-resolved-PV cache for merging partial/sticky metadata fields across messages */
   const pvCache = useRef<Record<string, PVData>>({});
+  /** pvState is keyed by resolved PV name (i.e. runtimePVName) */
   const [pvState, setPVState] = useState<Record<string, PVData>>({});
   /** Tracks which resolved PVs are currently subscribed on the server */
   const subscribedRef = useRef<Set<string>>(new Set());
-  /**
-   * Tracks the previous resolved→widgetPVs map so the subscription effect can
-   * detect widget PVs that have migrated to a different resolved PV.
-   */
-  const prevResolvedMapRef = useRef<Map<string, string[]>>(new Map());
-
-  /** Precompute reverse map for fast lookup (resolved PV → all widget PVs that point to it) */
-  const resolvedToWidgetPVs = useMemo(() => {
-    const map = new Map<string, string[]>();
-    PVMap.forEach((resolved, widgetPV) => {
-      const existing = map.get(resolved);
-      if (existing) {
-        existing.push(widgetPV);
-      } else {
-        map.set(resolved, [widgetPV]);
-      }
-    });
-    return map;
-  }, [PVMap]);
-
-  /** All resolved PV names for subscription */
-  const resolvedPVList = useMemo(() => Array.from(PVMap.values()), [PVMap]);
 
   /**
    * Handles incoming WebSocket messages.
-   * - Filters unsolicited PVs
-   * - Maps resolved PVs back to widget PV names
-   * - Populates metadata (received only once) with previous message content.
-   * - Updates PVState object
+   * Merges partial/sticky metadata fields and updates pvState keyed by resolved PV name.
    */
-  const onMessage = useCallback(
-    (msg: WSMessage) => {
-      const widgetPVs = resolvedToWidgetPVs.get(msg.pv);
-      if (!widgetPVs) {
-        console.warn(`received message from unsolicited PV: ${msg.pv}`);
-        return;
-      }
-
-      const prev = pvCache.current[msg.pv] ?? {};
-      const baseData = {
-        value: msg.value ?? prev.value,
-        enumChoices: msg.enumChoices ?? prev.enumChoices,
-        alarm: msg.alarm ?? prev.alarm,
-        timeStamp: msg.timeStamp ?? prev.timeStamp,
-        display: prev.display ?? msg.display,
-        control: prev.control ?? msg.control,
-        valueAlarm: prev.valueAlarm ?? msg.valueAlarm,
-      };
-      pvCache.current[msg.pv] = { pv: widgetPVs[0], ...baseData };
-      setPVState((prev) => {
-        const updates: Record<string, PVData> = {};
-        for (const widgetPV of widgetPVs) {
-          updates[widgetPV] = { pv: widgetPV, ...baseData };
-        }
-        return { ...prev, ...updates };
-      });
-    },
-    [resolvedToWidgetPVs],
-  );
+  const onMessage = useCallback((msg: WSMessage) => {
+    if (!subscribedRef.current.has(msg.pv)) {
+      console.warn(`received message from unsolicited PV: ${msg.pv}`);
+      return;
+    }
+    const prev = pvCache.current[msg.pv] ?? {};
+    const data: PVData = {
+      pv: msg.pv,
+      value: msg.value ?? prev.value,
+      enumChoices: msg.enumChoices ?? prev.enumChoices,
+      alarm: msg.alarm ?? prev.alarm,
+      timeStamp: msg.timeStamp ?? prev.timeStamp,
+      display: prev.display ?? msg.display,
+      control: prev.control ?? msg.control,
+      valueAlarm: prev.valueAlarm ?? msg.valueAlarm,
+    };
+    pvCache.current[msg.pv] = data;
+    setPVState((prev) => ({ ...prev, [msg.pv]: data }));
+  }, []);
 
   // Always kept up to date so the WSClient never captures a stale closure.
-  // Make sure resolvedToWidgetPVs updates are picked up w/o recreating WSClient.
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
   const stableMessageHandler = useRef<(msg: WSMessage) => void>((msg) => onMessageRef.current(msg));
@@ -101,17 +66,10 @@ export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["P
   );
 
   /**
-   * Reactively subscribes/unsubscribes PVs whenever the PV map changes or the
-   * session connects. This ensures EmbeddedDisplay children — which populate
-   * asynchronously after the initial connect — are subscribed as soon as they
-   * appear in the map, without restarting the session.
+   * Reactively subscribes/unsubscribes resolved PVs whenever the widget tree or
+   * rulePVList changes or the session connects.
    */
   useEffect(() => {
-    // Capture and advance the previous map before any early return so it
-    // stays in sync with every render that changes resolvedToWidgetPVs.
-    const prevResolvedMap = prevResolvedMapRef.current;
-    prevResolvedMapRef.current = resolvedToWidgetPVs;
-
     if (!wsConnected || !ws.current) {
       subscribedRef.current = new Set();
       return;
@@ -122,73 +80,19 @@ export default function useEpicsWS(PVMap: ReturnType<typeof useWidgetManager>["P
 
     const toAdd = resolvedPVList.filter((pv) => !prev.has(pv));
     const toRemove = [...prev].filter((pv) => !current.has(pv));
-    const toAddSet = new Set(toAdd);
 
     if (toAdd.length > 0) ws.current.subscribe(toAdd);
     if (toRemove.length > 0) {
       ws.current.unsubscribe(toRemove);
-      // Drop cached data for PVs that are no longer displayed
-      toRemove.forEach((pv) => {
-        delete pvCache.current[pv];
-      });
-    }
-
-    // Reconcile pvState for every widget PV that has just been remapped to a
-    // different resolved target (macro change, pvName rule action, etc.).
-    //
-    // Five sub-cases, handled in one unified pass:
-    //  A) Already-subscribed target, has cached data  → seed pvState from cache
-    //     (no new backend message will arrive for an already-subscribed PV)
-    //  B) Already-subscribed target, no cached data   → clear pvState so the
-    //     widget shows disconnected/invalid instead of the previous PV's value
-    //  C) Newly-subscribed target (in toAdd), valid   → clear pvState now;
-    //     the backend will push the real value once connected
-    //  D) Newly-subscribed target (in toAdd), invalid → same as C; the widget
-    //     correctly shows disconnected/invalid until the PV publishes
-    //  E) Widget PV removed from the map entirely      → clear stale pvState
-    //     (e.g., switching OPI files removes old widgets/PVs)
-    const widgetPVsToClear: string[] = [];
-    const migratedUpdates: Record<string, PVData> = {};
-
-    const currentWidgetPVSet = new Set<string>();
-    resolvedToWidgetPVs.forEach((widgetPVs) => {
-      for (const widgetPV of widgetPVs) currentWidgetPVSet.add(widgetPV);
-    });
-
-    prevResolvedMap.forEach((prevWidgetPVs) => {
-      for (const prevWidgetPV of prevWidgetPVs) {
-        if (!currentWidgetPVSet.has(prevWidgetPV)) {
-          widgetPVsToClear.push(prevWidgetPV);
-        }
-      }
-    });
-
-    resolvedToWidgetPVs.forEach((widgetPVs, resolved) => {
-      const cached = pvCache.current[resolved];
-      const prevWidgetPVs = new Set(prevResolvedMap.get(resolved) ?? []);
-      for (const widgetPV of widgetPVs) {
-        if (!prevWidgetPVs.has(widgetPV)) {
-          // Widget PV is newly mapped to `resolved`
-          if (cached && !toAddSet.has(resolved)) {
-            // already subscribed and backend has sent data, update immediately
-            migratedUpdates[widgetPV] = { ...cached, pv: widgetPV };
-          } else {
-            // no reliable data yet - drop stale pvState entry
-            widgetPVsToClear.push(widgetPV);
-          }
-        }
-      }
-    });
-    if (widgetPVsToClear.length > 0 || Object.keys(migratedUpdates).length > 0) {
+      toRemove.forEach((pv) => delete pvCache.current[pv]);
       setPVState((prev) => {
         const next = { ...prev };
-        for (const widgetPV of widgetPVsToClear) delete next[widgetPV];
-        return { ...next, ...migratedUpdates };
+        for (const pv of toRemove) delete next[pv];
+        return next;
       });
     }
-
     subscribedRef.current = current;
-  }, [resolvedPVList, wsConnected, resolvedToWidgetPVs]);
+  }, [resolvedPVList, wsConnected]);
 
   /**
    * Stops the current WebSocket session.

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import type {
   Widget,
   WidgetDefinition,
@@ -922,7 +922,7 @@ export function useWidgetManager() {
   /**
    * Macros to be substituted on pv names.
    * In runtime mode, effectiveGridMacroOverrides (computed by WidgetRenderer from fired rules)
-   * are merged on top of the GridZone's design-time macros so that PVMap stays in sync.
+   * are merged on top of the GridZone's design-time macros so that annotatedEditorWidgets stays in sync.
    */
   const [effectiveGridMacroOverrides, setEffectiveGridMacroOverrides] = useState<
     Record<string, string>
@@ -946,56 +946,69 @@ export function useWidgetManager() {
   );
 
   /**
-   * Map of all PVs held by widgets: { widget PV: macros-substituted PV }
+   * Stamps runtimePVName/runtimePVNames directly into editorWidgets whenever
+   * macros or PV-name properties change. No save in history.
    */
-  const PVMap = useMemo(() => {
-    const map = new Map<string, string>();
+  useEffect(() => {
+    const annotateWidget = (w: Widget): Widget => {
+      const pvName = w.editableProperties?.pvName?.value;
+      const pvNames = w.editableProperties?.pvNames?.value;
 
-    const collectPVs = (widgets: typeof editorWidgets) => {
+      const runtimePVName = pvName ? substituteMacros(pvName) : undefined;
+      const runtimePVNames = pvNames?.length ? pvNames.map(substituteMacros) : undefined;
+      const annotatedChildren = w.children?.map(annotateWidget);
+
+      const pvNameUnchanged = runtimePVName === w.runtimePVName;
+      const pvNamesUnchanged =
+        (!runtimePVNames && !w.runtimePVNames) ||
+        (runtimePVNames?.length === w.runtimePVNames?.length &&
+          runtimePVNames?.every((v, i) => v === w.runtimePVNames![i]));
+      const childrenUnchanged =
+        !annotatedChildren || annotatedChildren.every((c, i) => c === w.children![i]);
+
+      if (pvNameUnchanged && pvNamesUnchanged && childrenUnchanged) return w;
+
+      return {
+        ...w,
+        ...(runtimePVName !== undefined ? { runtimePVName } : {}),
+        ...(runtimePVNames !== undefined ? { runtimePVNames } : {}),
+        ...(annotatedChildren ? { children: annotatedChildren } : {}),
+      };
+    };
+
+    const annotated = editorWidgets.map(annotateWidget);
+    if (annotated.some((w, i) => w !== editorWidgets[i])) {
+      setEditorWidgets(annotated);
+    }
+  }, [editorWidgets, substituteMacros]);
+
+  /**
+   * Flat deduplicated list of all resolved PV names that need WebSocket subscriptions:
+   * widget runtimePVName/runtimePVNames values plus rule condition/action PV targets.
+   */
+  const resolvedPVList = useMemo(() => {
+    const pvSet = new Set<string>();
+    const collect = (widgets: Widget[]) => {
       for (const w of widgets) {
-        const single = w.editableProperties?.pvName?.value;
-        if (single) {
-          const substitutedSingle = substituteMacros(single);
-          if (substitutedSingle) {
-            map.set(single, substitutedSingle);
-          }
-        }
-
-        const multiPV = w.editableProperties?.pvNames?.value;
-        if (multiPV) {
-          Object.values(multiPV).forEach((pv) => {
-            const substituted = substituteMacros(pv);
-            if (substituted) {
-              map.set(pv, substituted);
-            }
-          });
-        }
-
+        if (w.runtimePVName) pvSet.add(w.runtimePVName);
+        if (w.runtimePVNames) for (const pv of w.runtimePVNames) pvSet.add(pv);
         for (const rule of w.rules ?? []) {
           for (const pv of rule.pvNames) {
             const substituted = substituteMacros(pv);
-            if (substituted) {
-              map.set(pv, substituted);
-            }
+            if (substituted) pvSet.add(substituted);
           }
           // Pre-subscribe pvName action targets so EpicsWS is ready before the rule fires
           const pvNameAction = rule.actions?.pvName;
           if (typeof pvNameAction === "string" && pvNameAction) {
             const substituted = substituteMacros(pvNameAction);
-            if (substituted) {
-              map.set(pvNameAction, substituted);
-            }
+            if (substituted) pvSet.add(substituted);
           }
         }
-
-        if (w.children && w.children.length > 0) {
-          collectPVs(w.children);
-        }
+        if (w.children?.length) collect(w.children);
       }
     };
-
-    collectPVs(editorWidgets);
-    return map;
+    collect(editorWidgets);
+    return [...pvSet];
   }, [editorWidgets, substituteMacros]);
 
   return {
@@ -1044,7 +1057,7 @@ export function useWidgetManager() {
     fileImportedTrig,
     updateWidgetRules,
     batchUpdateWidgetRules,
-    PVMap,
+    resolvedPVList,
     macros,
     allWidgetIDs,
     widgetIdMap,

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -169,6 +169,10 @@ export interface WidgetDefinition {
  * @property widgetName Registry key linking to the WidgetDefinition
  * @property editableProperties Current editable property values
  * @property children Optional child widgets (for group widgets)
+ * @property runtimePVName Runtime-only: macro-resolved form of editableProperties.pvName.value.
+ *   Set by useWidgetManager; never serialized.
+ * @property runtimePVNames Runtime-only: macro-resolved parallel array for editableProperties.pvNames.value.
+ *   Set by useWidgetManager; never serialized.
  * @property pvData Optional PV data, merged at render time only
  * @property multiPvData Optional multi-PV data, merged at render time only
  */
@@ -178,6 +182,8 @@ export interface Widget {
   editableProperties: WidgetProperties;
   rules?: Rule[];
   children?: Widget[];
+  runtimePVName?: string;
+  runtimePVNames?: string[];
   pvData?: PVData;
   multiPvData?: MultiPvData;
 }

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -48,6 +48,7 @@ export function substituteTextProps(
 
   const result: WidgetProperties = {};
   const resultRecord = result as Record<PropertyKey, WidgetProperty>;
+  let changed = false;
   for (const key of Object.keys(props) as PropertyKey[]) {
     const prop = props[key];
     if (!prop) {
@@ -55,16 +56,24 @@ export function substituteTextProps(
     }
     if (prop.selType === "text" && typeof prop.value === "string") {
       const substituted = substituteInStr(prop.value, macros);
-      resultRecord[key] = substituted !== prop.value ? { ...prop, value: substituted } : prop;
+      if (substituted !== prop.value) {
+        resultRecord[key] = { ...prop, value: substituted };
+        changed = true;
+      } else {
+        resultRecord[key] = prop;
+      }
     } else if (prop.selType === "strList" && Array.isArray(prop.value)) {
       const original = prop.value;
       const substituted = original.map((s) => substituteInStr(s, macros));
-      resultRecord[key] = substituted.some((s, i) => s !== original[i])
-        ? { ...prop, value: substituted }
-        : prop;
+      if (substituted.some((s, i) => s !== original[i])) {
+        resultRecord[key] = { ...prop, value: substituted };
+        changed = true;
+      } else {
+        resultRecord[key] = prop;
+      }
     } else {
       resultRecord[key] = prop;
     }
   }
-  return result;
+  return changed ? result : props;
 }


### PR DESCRIPTION
Up to now, macro-resolved PV names were not stored on the widget
objects. We had a shared object called "PVMap" that held the
translation between "macroized PVs" and substituted ones. On top of
that, several places were calling and repeating the macro
substitution process, and some redundant objects had to be created
for convenience, like "reversePVMap" and other hackish things.
I have been meaning to get rid of that for a while now, and with
some AI assistance, this PR does just that.

Solve that all by creating an optional runtime only property called
"runtimePVName". This will hold the corresponding substituted PV
name for the respective widget, so when consuming, one will always
have the source of truth of the solved macro in one place, and no 
longer needs to compute macro substitution anywhere else.

Closes #142 