### PR TITLE
General cleanup

### DIFF
--- a/src/components/GridZone/GridZoneComp.tsx
+++ b/src/components/GridZone/GridZoneComp.tsx
@@ -301,6 +301,8 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     isPlacementMode,
     pickedWidget,
     setDragPreview,
+    snapToGrid,
+    gridSize,
   ]);
 
   // Shortcuts handler

--- a/src/components/GridZone/GridZoneComp.tsx
+++ b/src/components/GridZone/GridZoneComp.tsx
@@ -1,19 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { GridPosition, WidgetDefinition, WidgetUpdate } from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
 import { usePVStore } from "@src/services/pvStore";
-import { createWidgetInstance } from "@src/context/widgetHelpers";
+import { createWidgetInstance, ensureGridCoordinate } from "@src/context/widgetHelpers";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
-import {
-  FRONT_UI_ZIDX,
-  GRID_ID,
-  MAX_ZOOM,
-  MIN_ZOOM,
-  ROUNDING_CONST,
-} from "@src/constants/constants";
+import { FRONT_UI_ZIDX, GRID_ID, MAX_ZOOM, MIN_ZOOM } from "@src/constants/constants";
 import ContextMenu from "@components/ContextMenu/ContextMenu";
 import "./GridZone.css";
 import WidgetRenderer from "@components/WidgetRenderer/WidgetRenderer.tsx";
@@ -65,8 +59,14 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     ungroupSelected,
     moveSelected,
     widgetIdMap,
+    setGridSize,
+    setSnapToGrid,
+    gridSize,
+    snapToGrid,
   } = useWidgetContext();
 
+  setGridSize(props.gridSize!.value);
+  setSnapToGrid(props.snapToGrid!.value);
   const gridRef = useRef<HTMLDivElement>(null);
   const lastPosRef = useRef<GridPosition>({ x: 0, y: 0 });
   const mousePosRef = useRef<GridPosition>({ x: 0, y: 0 });
@@ -85,17 +85,8 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     x: number;
     y: number;
   } | null>(null);
-  const gridSize = props.gridSize!.value;
-  const snapToGrid = props.snapToGrid?.value;
-  const gridLineVisible = props.gridLineVisible?.value;
 
-  const ensureGridCoordinate = useCallback(
-    (coord: number) => {
-      const aligned = snapToGrid ? Math.round(coord / gridSize) * gridSize : coord;
-      return Math.round(aligned * ROUNDING_CONST) / ROUNDING_CONST;
-    },
-    [snapToGrid, gridSize],
-  );
+  const gridLineVisible = props.gridLineVisible?.value;
 
   const centerScreen = () => {
     setZoom(1);
@@ -138,8 +129,8 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
 
     setDragPreview({
       widget: pickedWidget,
-      x: ensureGridCoordinate(userX),
-      y: ensureGridCoordinate(userY),
+      x: ensureGridCoordinate(userX, snapToGrid, gridSize),
+      y: ensureGridCoordinate(userY, snapToGrid, gridSize),
     });
   };
 
@@ -166,9 +157,9 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
 
     const newWidget = createWidgetInstance(droppedComp, `${entry.widgetName}-${uuidv4()}`);
     if (newWidget.editableProperties.x)
-      newWidget.editableProperties.x.value = ensureGridCoordinate(userX);
+      newWidget.editableProperties.x.value = ensureGridCoordinate(userX, snapToGrid, gridSize);
     if (newWidget.editableProperties.y)
-      newWidget.editableProperties.y.value = ensureGridCoordinate(userY);
+      newWidget.editableProperties.y.value = ensureGridCoordinate(userY, snapToGrid, gridSize);
 
     addWidget(newWidget);
     setDragPreview(null);
@@ -275,14 +266,14 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
       const userY = (rawY - pan.y) / zoom;
 
       mousePosRef.current = {
-        x: ensureGridCoordinate(userX),
-        y: ensureGridCoordinate(userY),
+        x: ensureGridCoordinate(userX, snapToGrid, gridSize),
+        y: ensureGridCoordinate(userY, snapToGrid, gridSize),
       };
       if (isPlacementMode && pickedWidget) {
         setDragPreview({
           widget: pickedWidget,
-          x: ensureGridCoordinate(userX),
-          y: ensureGridCoordinate(userY),
+          x: ensureGridCoordinate(userX, snapToGrid, gridSize),
+          y: ensureGridCoordinate(userY, snapToGrid, gridSize),
         });
       }
       if (gridGrabbed.current) {
@@ -304,7 +295,6 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
     gridGrabbed,
     isPanning,
     setIsPanning,
-    ensureGridCoordinate,
     pan,
     zoom,
     mode,
@@ -462,7 +452,7 @@ const GridZoneComp: React.FC<WidgetUpdate> = ({ data }) => {
             }}
           />
         )}
-        <WidgetRenderer scale={zoom} ensureGridCoordinate={ensureGridCoordinate} />
+        <WidgetRenderer scale={zoom} />
       </div>
       {inEditMode && <SelectionManager gridRef={gridRef} zoom={zoom} pan={pan} />}
       <ToolbarButtons />

--- a/src/components/GridZone/SelectionManager/SelectionManager.tsx
+++ b/src/components/GridZone/SelectionManager/SelectionManager.tsx
@@ -2,7 +2,6 @@
 // Copyright (C) 2026 André Favoto
 
 import { FRONT_UI_ZIDX, GRID_ID } from "@src/constants/constants";
-import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { getTopLevelId } from "@src/context/widgetHelpers";
 import React, { useRef, useState, useEffect } from "react";
@@ -17,8 +16,7 @@ interface SelectionManagerProps {
 const CLICK_THRESHOLD = 3;
 
 const SelectionManager: React.FC<SelectionManagerProps> = ({ gridRef, zoom, pan }) => {
-  const { editorWidgets, setSelectedWidgetIDs, selectedWidgetIDs } = useWidgetContext();
-  const { isDragging } = useUIContext();
+  const { editorWidgets, setSelectedWidgetIDs, selectedWidgetIDs, isDragging } = useWidgetContext();
   const [selectionArea, setSelectionArea] = useState<{
     start?: { x: number; y: number };
     end?: { x: number; y: number };

--- a/src/components/WidgetRenderer/LiveWidget.tsx
+++ b/src/components/WidgetRenderer/LiveWidget.tsx
@@ -10,8 +10,6 @@ import { usePVStore } from "@src/services/pvStore";
 import { substituteMacroInStr } from "@src/utils/macros";
 import { applyWidgetPVData } from "./widgetRenderUtils";
 
-const EMPTY_PVS: Record<string, PVData> = {};
-
 /**
  * Renders a single widget's content by subscribing only to the PV(s) that
  * widget actually uses.  React.memo + the per-PV Zustand selector guarantee
@@ -49,11 +47,11 @@ const LiveWidget = memo(function WidgetRenderItem({
     return [...names];
   }, [w, globalMacros]);
 
-  // Subscribe only to this widget's relevant PVs.
+  // Subscribe (from Zustand store) only to this widget's relevant PVs.
   // `useShallow` ensures re-render only when any selected value changes by reference.
   const relevantPvs = usePVStore(
     useShallow((state) => {
-      if (!pvNames.length) return EMPTY_PVS;
+      if (!pvNames.length) return {};
       const result: Record<string, PVData> = {};
       for (const pv of pvNames) {
         const d = state.pvs[pv];

--- a/src/components/WidgetRenderer/LiveWidget.tsx
+++ b/src/components/WidgetRenderer/LiveWidget.tsx
@@ -7,7 +7,7 @@ import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import type { Widget } from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
 import { usePVStore } from "@src/services/pvStore";
-import { substituteInStr } from "@src/utils/macros";
+import { substituteMacroInStr } from "@src/utils/macros";
 import { applyWidgetPVData } from "./widgetRenderUtils";
 
 const EMPTY_PVS: Record<string, PVData> = {};
@@ -37,12 +37,12 @@ const LiveWidget = memo(function WidgetRenderItem({
     w.runtimePVNames?.forEach((pv) => names.add(pv));
     w.rules?.forEach((rule) => {
       rule.pvNames.forEach((pv) => {
-        const resolved = substituteInStr(pv, globalMacros);
+        const resolved = substituteMacroInStr(pv, globalMacros);
         if (resolved) names.add(resolved);
       });
       // Rule action may reference a separate write PV.
       if (typeof rule.actions?.pvName === "string" && rule.actions.pvName) {
-        const resolved = substituteInStr(rule.actions.pvName, globalMacros);
+        const resolved = substituteMacroInStr(rule.actions.pvName, globalMacros);
         if (resolved) names.add(resolved);
       }
     });
@@ -63,7 +63,7 @@ const LiveWidget = memo(function WidgetRenderItem({
     }),
   );
 
-  // Inject pvData + pvvalue/pvname macros + rule overrides.
+  // Inject pvData + runtime macros + rule overrides.
   const mergedWidget = useMemo(
     () => applyWidgetPVData(w, relevantPvs, globalMacros),
     [w, relevantPvs, globalMacros],

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import React, { useEffect, useMemo, useRef, type ReactNode } from "react";
+import React, { useEffect, useRef, type ReactNode } from "react";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import type { Widget, MultiWidgetPropertyUpdates, DOMRectLike } from "@src/types/widgets";
 import { Rnd, type DraggableData, type Position, type RndDragEvent } from "react-rnd";
@@ -10,7 +10,7 @@ import "./WidgetRenderer.css";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { usePVStore } from "@src/services/pvStore";
-import { hasSelectedDescendant, applyGlobalMacros } from "./widgetRenderUtils";
+import { hasSelectedDescendant } from "./widgetRenderUtils";
 import LiveWidget from "./LiveWidget";
 import { collectGlobalMacroOverrides } from "@src/utils/macros";
 
@@ -30,20 +30,13 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
     updateWidgetProperties,
     selectedWidgets,
     setMacroOverrides,
-    macros: contextMacros,
+    baseGlobalMacros,
+    globalMacros,
   } = useWidgetContext();
 
-  const prevGlobalMacrosRef = useRef<Record<string, string>>({});
-
-  const baseGlobalMacros = useMemo(
-    () => editorWidgets.find((w) => w.id === GRID_ID)?.editableProperties.macros?.value ?? {},
-    [editorWidgets],
-  );
-
-  // Keep macroOverrides in sync with live PV data via a Zustand
-  // subscription.  This runs off the render cycle — WidgetRenderer only
-  // re-renders if the computed overrides actually change.
   const prevGlobalMacrosJsonRef = useRef<string>("");
+
+  // Keep macroOverrides in sync with live PV data based on rules evaluation.
   useEffect(() => {
     if (inEditMode) return;
     const unsubscribe = usePVStore.subscribe((state) => {
@@ -56,21 +49,6 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
     });
     return unsubscribe;
   }, [editorWidgets, baseGlobalMacros, inEditMode, setMacroOverrides]);
-
-  // globalMacros = design-time macros merged with any rule-driven overrides.
-  // We read this from WidgetContext (useWidgetManager.macros) rather than from
-  // editorWidgets[GRID_ID].editableProperties.macros.value, because the latter
-  // only ever holds design-time values — macroOverrides are merged
-  // inside useWidgetManager but never written back into the grid widget property.
-  const globalMacros = useMemo(() => contextMacros ?? {}, [contextMacros]);
-
-  // Layout computation: applies grid-macro substitution to all widget text props.
-  const widgetsForLayout = useMemo(() => {
-    if (inEditMode) return editorWidgets;
-    const { applied } = applyGlobalMacros(editorWidgets, globalMacros);
-    prevGlobalMacrosRef.current = globalMacros;
-    return applied;
-  }, [editorWidgets, globalMacros, inEditMode]);
 
   /** Core widget content renderer, delegates PV data to LiveWidget */
   const renderWidgetContent = (w: Widget): ReactNode => {
@@ -273,7 +251,7 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
     );
   };
 
-  const topLevelWidgets = widgetsForLayout.filter((w) => w.id !== GRID_ID);
+  const topLevelWidgets = editorWidgets.filter((w) => w.id !== GRID_ID);
 
   return (
     <>

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -1,54 +1,34 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import React, { useEffect, useRef, type ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
-import type { Widget, MultiWidgetPropertyUpdates, DOMRectLike } from "@src/types/widgets";
-import { Rnd, type DraggableData, type Position, type RndDragEvent } from "react-rnd";
+import type { Widget } from "@src/types/widgets";
+import { Rnd } from "react-rnd";
 import { GRID_ID } from "@src/constants/constants";
 import "./WidgetRenderer.css";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
-import { usePVStore } from "@src/services/pvStore";
 import { hasSelectedDescendant } from "./widgetRenderUtils";
 import LiveWidget from "./LiveWidget";
-import { collectGlobalMacroOverrides } from "@src/utils/macros";
-
-const DRAG_END_DELAY = 80; //ms
 interface RendererProps {
   scale: number;
-  ensureGridCoordinate: (coord: number) => number;
 }
 
-const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }) => {
-  const { inEditMode, setIsDragging, isPanning, isTextEditing } = useUIContext();
+const WidgetRenderer: React.FC<RendererProps> = ({ scale }) => {
+  const { inEditMode, isPanning, isTextEditing } = useUIContext();
   const {
     editorWidgets,
     selectedWidgetIDs,
-    batchWidgetUpdate,
     selectionBounds,
-    updateWidgetProperties,
     selectedWidgets,
-    setMacroOverrides,
-    baseGlobalMacros,
+    setIsDragging,
     globalMacros,
+    handleDragStop,
+    handleResizeStop,
+    handleSelGroupDragStop,
+    handleSelGroupResizeStop,
   } = useWidgetContext();
-
-  const prevGlobalMacrosJsonRef = useRef<string>("");
-
-  // Keep macroOverrides in sync with live PV data based on rules evaluation.
-  useEffect(() => {
-    if (inEditMode) return;
-    const unsubscribe = usePVStore.subscribe((state) => {
-      const overrides = collectGlobalMacroOverrides(editorWidgets, state.pvs, baseGlobalMacros);
-      const json = JSON.stringify(overrides);
-      if (json !== prevGlobalMacrosJsonRef.current) {
-        prevGlobalMacrosJsonRef.current = json;
-        setMacroOverrides(overrides);
-      }
-    });
-    return unsubscribe;
-  }, [editorWidgets, baseGlobalMacros, inEditMode, setMacroOverrides]);
 
   /** Core widget content renderer, delegates PV data to LiveWidget */
   const renderWidgetContent = (w: Widget): ReactNode => {
@@ -58,73 +38,6 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
       return Comp ? <Comp data={w} /> : null;
     }
     return <LiveWidget w={w} globalMacros={globalMacros} />;
-  };
-
-  const handleDragStop = (_e: RndDragEvent, d: DraggableData, w: Widget) => {
-    setIsDragging(false);
-    if (w.editableProperties.x?.value == d.x && w.editableProperties.y?.value == d.y) return;
-    updateWidgetProperties(w.id, {
-      x: ensureGridCoordinate(d.x),
-      y: ensureGridCoordinate(d.y),
-    });
-  };
-
-  const handleResizeStop = (ref: HTMLElement, position: Position, w: Widget) => {
-    setIsDragging(false);
-    const newWidth = ensureGridCoordinate(parseInt(ref.style.width));
-    const newHeight = ensureGridCoordinate(parseInt(ref.style.height));
-    const newX = ensureGridCoordinate(position.x);
-    const newY = ensureGridCoordinate(position.y);
-
-    if (
-      w.editableProperties.width?.value === newWidth &&
-      w.editableProperties.height?.value === newHeight
-    )
-      return;
-
-    updateWidgetProperties(w.id, { width: newWidth, height: newHeight, x: newX, y: newY });
-  };
-
-  const handleSelGroupResizeStop = (ref: HTMLElement, bounds: DOMRectLike, widgets: Widget[]) => {
-    setIsDragging(false);
-    const newGroupWidth = ref.offsetWidth;
-    const newGroupHeight = ref.offsetHeight;
-    const scaleX = newGroupWidth / bounds.width;
-    const scaleY = newGroupHeight / bounds.height;
-
-    const updates: MultiWidgetPropertyUpdates = {};
-    widgets.forEach((w) => {
-      const { width, height, x, y } = {
-        width: w.editableProperties.width!.value,
-        height: w.editableProperties.height!.value,
-        x: w.editableProperties.x!.value,
-        y: w.editableProperties.y!.value,
-      };
-      const relativeX = x - bounds.x;
-      const relativeY = y - bounds.y;
-      updates[w.id] = {
-        width: ensureGridCoordinate(width * scaleX),
-        height: ensureGridCoordinate(height * scaleY),
-        x: ensureGridCoordinate(bounds.x + relativeX * scaleX),
-        y: ensureGridCoordinate(bounds.y + relativeY * scaleY),
-      };
-    });
-    batchWidgetUpdate(updates);
-  };
-
-  const handleSelGroupDragStop = (dx: number, dy: number) => {
-    setTimeout(() => setIsDragging(false), DRAG_END_DELAY);
-    const updates: MultiWidgetPropertyUpdates = {};
-    selectedWidgets.forEach((widget) => {
-      const xProp = widget.editableProperties.x;
-      const yProp = widget.editableProperties.y;
-      if (!xProp || !yProp) return;
-      updates[widget.id] = {
-        x: ensureGridCoordinate(xProp.value + dx),
-        y: ensureGridCoordinate(yProp.value + dy),
-      };
-    });
-    batchWidgetUpdate(updates);
   };
 
   const renderRecursive = (

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -3,24 +3,16 @@
 
 import React, { useEffect, useMemo, useRef, type ReactNode } from "react";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
-import type {
-  Widget,
-  MultiWidgetPropertyUpdates,
-  DOMRectLike,
-  WidgetProperties,
-} from "@src/types/widgets";
+import type { Widget, MultiWidgetPropertyUpdates, DOMRectLike } from "@src/types/widgets";
 import { Rnd, type DraggableData, type Position, type RndDragEvent } from "react-rnd";
 import { GRID_ID } from "@src/constants/constants";
 import "./WidgetRenderer.css";
 import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { usePVStore } from "@src/services/pvStore";
-import {
-  hasSelectedDescendant,
-  collectGlobalMacroOverrides,
-  applyGlobalMacros,
-} from "./widgetRenderUtils";
+import { hasSelectedDescendant, applyGlobalMacros } from "./widgetRenderUtils";
 import LiveWidget from "./LiveWidget";
+import { collectGlobalMacroOverrides } from "@src/utils/macros";
 
 const DRAG_END_DELAY = 80; //ms
 interface RendererProps {
@@ -41,17 +33,14 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
     macros: contextMacros,
   } = useWidgetContext();
 
-  const prevWidgetsMapRef = useRef<Map<string, Widget>>(new Map());
-  const prevRawPropsMapRef = useRef<Map<string, WidgetProperties>>(new Map());
   const prevGlobalMacrosRef = useRef<Record<string, string>>({});
-  const prevInEditModeRef = useRef(inEditMode);
 
   const baseGlobalMacros = useMemo(
     () => editorWidgets.find((w) => w.id === GRID_ID)?.editableProperties.macros?.value ?? {},
     [editorWidgets],
   );
 
-  // Keep effectiveGridMacroOverrides in sync with live PV data via a Zustand
+  // Keep macroOverrides in sync with live PV data via a Zustand
   // subscription.  This runs off the render cycle — WidgetRenderer only
   // re-renders if the computed overrides actually change.
   const prevGlobalMacrosJsonRef = useRef<string>("");
@@ -75,28 +64,12 @@ const WidgetRenderer: React.FC<RendererProps> = ({ scale, ensureGridCoordinate }
   // inside useWidgetManager but never written back into the grid widget property.
   const globalMacros = useMemo(() => contextMacros ?? {}, [contextMacros]);
 
-  // Layout computation: applies grid-macro substitution to all widget props.
+  // Layout computation: applies grid-macro substitution to all widget text props.
   const widgetsForLayout = useMemo(() => {
-    const modeChanged = inEditMode !== prevInEditModeRef.current;
-    prevInEditModeRef.current = inEditMode;
-    const prevWidgetsMap = modeChanged ? new Map<string, Widget>() : prevWidgetsMapRef.current;
-    const prevRawPropsMap = modeChanged
-      ? new Map<string, WidgetProperties>()
-      : prevRawPropsMapRef.current;
-    const prevGlobalMacros = modeChanged ? {} : prevGlobalMacrosRef.current;
-
-    const { result, nextWidgetsMap, nextRawPropsMap } = applyGlobalMacros(
-      editorWidgets,
-      globalMacros,
-      inEditMode,
-      prevWidgetsMap,
-      prevRawPropsMap,
-      prevGlobalMacros,
-    );
-    prevWidgetsMapRef.current = nextWidgetsMap;
-    prevRawPropsMapRef.current = nextRawPropsMap;
+    if (inEditMode) return editorWidgets;
+    const { applied } = applyGlobalMacros(editorWidgets, globalMacros);
     prevGlobalMacrosRef.current = globalMacros;
-    return result;
+    return applied;
   }, [editorWidgets, globalMacros, inEditMode]);
 
   /** Core widget content renderer, delegates PV data to LiveWidget */

--- a/src/components/WidgetRenderer/widgetRenderUtils.ts
+++ b/src/components/WidgetRenderer/widgetRenderUtils.ts
@@ -1,47 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import type { Widget, WidgetProperties } from "@src/types/widgets";
+import type { Widget } from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
-import { flattenWidgetTree } from "@src/context/widgetHelpers";
 import { buildInternalMacros, substituteTextProps } from "@src/utils/macros";
 import { evaluateRules } from "@src/utils/ruleEngine";
 
 // Selection helpers
 export const hasSelectedDescendant = (w: Widget, selectedIDs: string[]): boolean =>
   !!w.children?.some((c) => selectedIDs.includes(c.id) || hasSelectedDescendant(c, selectedIDs));
-
-// globalMacros override computation
-
-/**
- * Walks every widget in the tree (including nested children), evaluates their
- * rules against the current PV state, and aggregates any `globalMacros` action
- * values into a single merged map.  Called from the `usePVStore.subscribe()`
- * effect in WidgetRenderer; only runs in runtime mode.
- */
-export function collectGlobalMacroOverrides(
-  widgets: Widget[],
-  pvState: Record<string, PVData>,
-  baseGlobalMacros: Record<string, string>,
-): Record<string, string> {
-  let merged: Record<string, string> = {};
-  for (const w of flattenWidgetTree(widgets)) {
-    if (!w.rules?.length) continue;
-    const wPvName = w.runtimePVName;
-    const wPvData = wPvName ? pvState[wPvName] : undefined;
-    const wInternalMacros = buildInternalMacros(wPvName, wPvData);
-    const wMacros =
-      Object.keys(wInternalMacros).length > 0
-        ? { ...baseGlobalMacros, ...wInternalMacros }
-        : baseGlobalMacros;
-    const wRuleEvalMacros = wPvName ? { ...wMacros, "$(pvname)": wPvName } : wMacros;
-    const wOverrides = evaluateRules(w.rules, pvState, wRuleEvalMacros);
-    if (wOverrides.globalMacros && typeof wOverrides.globalMacros === "object") {
-      merged = { ...merged, ...(wOverrides.globalMacros as Record<string, string>) };
-    }
-  }
-  return merged;
-}
 
 /**
  * Injects live PV data into a single widget: resolves pvvalue/pvname macros,
@@ -121,57 +88,21 @@ export function applyWidgetPVData(
 
 /**
  * Substitutes grid macros (design-time + rule-driven overrides) into every
- * widget's text properties.  Results are cached by raw `editableProperties`
- * reference and `globalMacros` reference, so unchanged widgets are returned
- * as stable object references, preventing unnecessary `LiveWidget`
- * re-renders.  PV data injection and per-widget rule evaluation are
- * deliberately omitted; those happen inside `LiveWidget`.
+ * widget's text properties (e.g. labels, axis name, tooltip, etc).
  */
 export function applyGlobalMacros(
   editorWidgets: Widget[],
   globalMacros: Record<string, string>,
-  inEditMode: boolean,
-  prevWidgetsMap: Map<string, Widget>,
-  prevRawPropsMap: Map<string, WidgetProperties>,
-  prevGlobalMacros: Record<string, string>,
 ): {
-  result: Widget[];
-  nextWidgetsMap: Map<string, Widget>;
-  nextRawPropsMap: Map<string, WidgetProperties>;
+  applied: Widget[];
 } {
-  const nextWidgetsMap = new Map<string, Widget>();
-  const nextRawPropsMap = new Map<string, WidgetProperties>();
-
-  const mergeLayout = (w: Widget): Widget => {
-    nextRawPropsMap.set(w.id, w.editableProperties);
-
-    if (inEditMode) {
-      nextWidgetsMap.set(w.id, w);
-      return w;
-    }
-
-    const newChildren = w.children?.map(mergeLayout);
-
-    // Return cached widget if nothing changed.
-    // globalMacros reference equality: if macros changed, recompute unconditionally.
-    const macrosStable = globalMacros === prevGlobalMacros;
-    const structureStable = prevRawPropsMap.get(w.id) === w.editableProperties;
-    const childrenStable =
-      !newChildren || newChildren.every((c, i) => c === prevWidgetsMap.get(w.children![i].id));
-    if (macrosStable && structureStable && childrenStable) {
-      const cached = prevWidgetsMap.get(w.id);
-      if (cached) {
-        nextWidgetsMap.set(w.id, cached);
-        return cached;
-      }
-    }
-
+  const applyMacrosRecursive = (w: Widget): Widget => {
+    const newChildren = w.children?.map(applyMacrosRecursive);
     const substitutedProps = substituteTextProps(w.editableProperties, globalMacros);
     const merged: Widget = { ...w, editableProperties: substitutedProps, children: newChildren };
-    nextWidgetsMap.set(w.id, merged);
     return merged;
   };
 
-  const result = editorWidgets.map(mergeLayout);
-  return { result, nextWidgetsMap, nextRawPropsMap };
+  const applied = editorWidgets.map(applyMacrosRecursive);
+  return { applied };
 }

--- a/src/components/WidgetRenderer/widgetRenderUtils.ts
+++ b/src/components/WidgetRenderer/widgetRenderUtils.ts
@@ -28,7 +28,8 @@ export function applyWidgetPVData(
   const pvNames = w.runtimePVNames;
 
   /**
-   * TODO: this should be multiple functions. So far, workflow is:
+   * TODO: this should be split into multiple functions.
+   * So far, workflow is:
    * 1 - Apply received pvData (before rules)
    * 2 - Populate internal content ($(pvname), $(pvvalue), etc)
    * 3 - Evaluate rules against these.
@@ -44,7 +45,7 @@ export function applyWidgetPVData(
       ? { ...globalMacros, ...origInternalMacros }
       : globalMacros;
   const ovr = evaluateRules(w.rules ?? [], runtimeData, allMacros);
-  // skip globalMacros — handled globally at grid level
+  // skip globalMacros rules — handled globally for all widgets
   const ruleOverrides = Object.fromEntries(
     Object.entries(ovr).filter(([k]) => k !== "globalMacros"),
   );

--- a/src/components/WidgetRenderer/widgetRenderUtils.ts
+++ b/src/components/WidgetRenderer/widgetRenderUtils.ts
@@ -3,8 +3,8 @@
 
 import type { Widget } from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
-import { buildInternalMacros, substituteTextProps } from "@src/utils/macros";
-import { evaluateRules } from "@src/utils/ruleEngine";
+import { buildRuntimeMacros, substituteTextProps } from "@src/utils/macros";
+import { applyRules, evaluateRules } from "@src/utils/ruleEngine";
 
 // Selection helpers
 export const hasSelectedDescendant = (w: Widget, selectedIDs: string[]): boolean =>
@@ -21,88 +21,67 @@ export const hasSelectedDescendant = (w: Widget, selectedIDs: string[]): boolean
  */
 export function applyWidgetPVData(
   w: Widget,
-  relevantPvs: Record<string, PVData>,
+  runtimeData: Record<string, PVData>,
   globalMacros: Record<string, string>,
 ): Widget {
   const pvName = w.runtimePVName;
   const pvNames = w.runtimePVNames;
 
+  /**
+   * TODO: this should be multiple functions. So far, workflow is:
+   * 1 - Apply received pvData (before rules)
+   * 2 - Populate internal content ($(pvname), $(pvvalue), etc)
+   * 3 - Evaluate rules against these.
+   * 4 - If the rules change the PV name, re-populate internal content
+   * 5 - Replace macros present in all text fields
+   * 6 - Apply rule overrides to widget and return it
+   * */
   // Build macros for rule evaluation using the widget's primary PV.
-  const origPvData = pvName ? relevantPvs[pvName] : undefined;
-  const origInternalMacros = buildInternalMacros(pvName, origPvData);
-  const origAllMacros =
+  const origPvData = pvName ? runtimeData[pvName] : undefined;
+  const origInternalMacros = buildRuntimeMacros(pvName, origPvData);
+  let allMacros =
     Object.keys(origInternalMacros).length > 0
       ? { ...globalMacros, ...origInternalMacros }
       : globalMacros;
-  const ruleEvalMacros = pvName ? { ...origAllMacros, "$(pvname)": pvName } : origAllMacros;
-  const ruleOverrides = evaluateRules(w.rules ?? [], relevantPvs, ruleEvalMacros);
-
+  const ovr = evaluateRules(w.rules ?? [], runtimeData, allMacros);
+  // skip globalMacros — handled globally at grid level
+  const ruleOverrides = Object.fromEntries(
+    Object.entries(ovr).filter(([k]) => k !== "globalMacros"),
+  );
   // Derive effective pvName from a rule override, if any.
   const effectivePvName =
     typeof ruleOverrides.pvName === "string" && ruleOverrides.pvName
       ? ruleOverrides.pvName
       : pvName;
 
-  const pvData = effectivePvName ? relevantPvs[effectivePvName] : undefined;
+  const pvData = effectivePvName ? runtimeData[effectivePvName] : undefined;
   let multiPvData: Record<string, PVData> | undefined;
   if (pvNames?.length) {
     multiPvData = {};
     for (const resolved of pvNames) {
-      const d = relevantPvs[resolved];
+      const d = runtimeData[resolved];
       if (d) multiPvData[resolved] = d;
     }
   }
 
   const withPVData: Widget = { ...w, pvData, multiPvData };
 
-  // Re-substitute macros that depend on the live PV value ($(pvvalue), $(pvname)).
-  const internalMacros = buildInternalMacros(effectivePvName, pvData);
-  const allMacros =
-    Object.keys(internalMacros).length > 0 ? { ...globalMacros, ...internalMacros } : globalMacros;
+  if (effectivePvName !== pvName) {
+    /**
+     * In case PV name was changed by rules,
+     * update content that depend on the live PV value ($(pvvalue), $(pvdesc)).
+     * */
+    const internalMacros = buildRuntimeMacros(effectivePvName, pvData);
+    allMacros =
+      Object.keys(internalMacros).length > 0
+        ? { ...globalMacros, ...internalMacros }
+        : globalMacros;
+  }
+  // Replace macro content in all properties with text (labels, axis title, tooltip, etc)
   const substitutedProps = substituteTextProps(withPVData.editableProperties, allMacros);
-  const withMacros: Widget = { ...withPVData, editableProperties: substitutedProps };
-
-  // Apply per-widget rule overrides (skip globalMacros — handled at grid level).
-  const perWidgetOverrides = Object.fromEntries(
-    Object.entries(ruleOverrides).filter(([k]) => k !== "globalMacros"),
-  );
-  if (!Object.keys(perWidgetOverrides).length) return withMacros;
-
-  return {
-    ...withMacros,
-    editableProperties: Object.fromEntries(
-      Object.entries(withMacros.editableProperties).map(([key, prop]) => {
-        const override = perWidgetOverrides[key as keyof typeof perWidgetOverrides];
-        if (override === undefined) return [key, prop];
-        if (key === "macros" && typeof override === "object" && !Array.isArray(override)) {
-          return [
-            key,
-            { ...prop, value: { ...(prop.value as Record<string, string>), ...override } },
-          ];
-        }
-        return [key, { ...prop, value: override }];
-      }),
-    ) as typeof withMacros.editableProperties,
-  };
-}
-
-/**
- * Substitutes grid macros (design-time + rule-driven overrides) into every
- * widget's text properties (e.g. labels, axis name, tooltip, etc).
- */
-export function applyGlobalMacros(
-  editorWidgets: Widget[],
-  globalMacros: Record<string, string>,
-): {
-  applied: Widget[];
-} {
-  const applyMacrosRecursive = (w: Widget): Widget => {
-    const newChildren = w.children?.map(applyMacrosRecursive);
-    const substitutedProps = substituteTextProps(w.editableProperties, globalMacros);
-    const merged: Widget = { ...w, editableProperties: substitutedProps, children: newChildren };
-    return merged;
-  };
-
-  const applied = editorWidgets.map(applyMacrosRecursive);
-  return { applied };
+  const substituted: Widget = { ...withPVData, editableProperties: substitutedProps };
+  const finalWidget = Object.keys(ruleOverrides).length
+    ? applyRules(substituted, ruleOverrides)
+    : substituted;
+  return finalWidget;
 }

--- a/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplayComp.tsx
+++ b/src/components/Widgets/EmbeddedDisplay/EmbeddedDisplayComp.tsx
@@ -8,7 +8,7 @@ import { useUIContext } from "@src/context/useUIContext";
 import { useWidgetContext } from "@src/context/useWidgetContext";
 import { getDeployedRepoFile, getStagingRepoFile } from "@src/services/APIClient";
 import { resolveRepoPath } from "@src/utils/repoPath";
-import { substituteInStr, substituteTextProps } from "@src/utils/macros";
+import { substituteMacroInStr, substituteTextProps } from "@src/utils/macros";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import { createGroupWidget } from "@src/context/widgetHelpers";
 import type { PropertyKey } from "@src/types/widgets";
@@ -128,7 +128,7 @@ function applyMacros(widgets: Widget[], macros: Record<string, string>): Widget[
     if (props.pvName?.value) {
       props = {
         ...props,
-        pvName: { ...props.pvName, value: substituteInStr(props.pvName.value, macros) },
+        pvName: { ...props.pvName, value: substituteMacroInStr(props.pvName.value, macros) },
       };
     }
     if (props.pvNames?.value && props.pvNames.value.length > 0) {
@@ -136,7 +136,7 @@ function applyMacros(widgets: Widget[], macros: Record<string, string>): Widget[
         ...props,
         pvNames: {
           ...props.pvNames,
-          value: props.pvNames.value.map((pv) => substituteInStr(pv, macros)),
+          value: props.pvNames.value.map((pv) => substituteMacroInStr(pv, macros)),
         },
       };
     }

--- a/src/context/ContextProvider.tsx
+++ b/src/context/ContextProvider.tsx
@@ -39,6 +39,8 @@ const UIProvider = memo(function UIProvider({
     loadWidgets,
     snapshotEditModeMacros,
     restoreEditModeMacros,
+    baseGlobalMacros,
+    setMacroOverrides,
   } = useWidgetContext();
 
   const ui = useUIManager(
@@ -54,6 +56,8 @@ const UIProvider = memo(function UIProvider({
     loadWidgets,
     snapshotEditModeMacros,
     restoreEditModeMacros,
+    baseGlobalMacros,
+    setMacroOverrides,
   );
 
   return <UIContext.Provider value={ui}>{children}</UIContext.Provider>;

--- a/src/context/useUIManager.ts
+++ b/src/context/useUIManager.ts
@@ -25,6 +25,8 @@ import {
   type TokenStatus,
   type User,
 } from "@src/services/APIClient";
+import { usePVStore } from "@src/services/pvStore";
+import { collectGlobalMacroOverrides } from "@src/utils/macros";
 
 const IMAGE_EXTENSIONS = new Set([".svg", ".png", ".jpg", ".jpeg"]);
 const MIME_MAP: Record<string, string> = {
@@ -66,6 +68,8 @@ export default function useUIManager(
   loadWidgets: ReturnType<typeof useWidgetManager>["loadWidgets"],
   snapshotEditModeMacros: ReturnType<typeof useWidgetManager>["snapshotEditModeMacros"],
   restoreEditModeMacros: ReturnType<typeof useWidgetManager>["restoreEditModeMacros"],
+  baseGlobalMacros: ReturnType<typeof useWidgetManager>["baseGlobalMacros"],
+  setMacroOverrides: ReturnType<typeof useWidgetManager>["setMacroOverrides"],
 ) {
   const hasFileChanged = useRef(true);
   const restoredRef = useRef(false);
@@ -74,7 +78,6 @@ export default function useUIManager(
   const [isTextEditing, setIsTextEditing] = useState(false);
   const [wdgPickerOpen, setWdgPickerOpen] = useState(false);
   const [mode, setMode] = useState<Mode>(EDIT_MODE);
-  const [isDragging, setIsDragging] = useState(false);
   const [isPanning, setIsPanning] = useState(false);
   const [user, setUser] = useState<User | null>(() => authService.getUser());
   const [authChecked, setAuthChecked] = useState(false);
@@ -317,6 +320,22 @@ export default function useUIManager(
       }
     };
   }, [editorWidgets, selectedFile, isDeveloper, inEditMode, formatWdgToExport, setReposTreeInfo]);
+  const prevGlobalMacrosJsonRef = useRef<string>("");
+
+  // Keep macroOverrides in sync with live PV data based on rules evaluation.
+  // This is needed because macros can be overriden via rules during runtime
+  useEffect(() => {
+    if (inEditMode) return;
+    const unsubscribe = usePVStore.subscribe((state) => {
+      const overrides = collectGlobalMacroOverrides(editorWidgets, state.pvs, baseGlobalMacros);
+      const json = JSON.stringify(overrides);
+      if (json !== prevGlobalMacrosJsonRef.current) {
+        prevGlobalMacrosJsonRef.current = json;
+        setMacroOverrides(overrides);
+      }
+    });
+    return unsubscribe;
+  }, [editorWidgets, baseGlobalMacros, inEditMode, setMacroOverrides]);
 
   return useMemo(
     () => ({
@@ -327,8 +346,6 @@ export default function useUIManager(
       wdgPickerOpen,
       setWdgPickerOpen,
       inEditMode,
-      isDragging,
-      setIsDragging,
       isPanning,
       setIsPanning,
       isDemo,
@@ -358,7 +375,6 @@ export default function useUIManager(
       wdgPickerOpen,
       mode,
       inEditMode,
-      isDragging,
       isPanning,
       user,
       isDeveloper,

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -26,11 +26,13 @@ import {
   createWidgetInstance,
   deepCloneWidget,
   deepCloneWidgetList,
+  ensureGridCoordinate,
   getNestedMoveUpdates,
   getSelectedWidgets,
   getWidgetNested,
   updateWidgets,
 } from "./widgetHelpers";
+import type { DraggableData, Position, RndDragEvent } from "react-rnd";
 
 /**
  * Hook to manage the editor's widgets and their state.
@@ -52,10 +54,14 @@ export function useWidgetManager() {
   ]);
   const [pickedWidget, setPickedWidget] = useState<WidgetDefinition | null>(null); // widget picked from palette
   const [isPlacementMode, setIsPlacementMode] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const [selectedWidgetIDs, setSelectedWidgetIDs] = useState<string[]>([]);
   const [fileLoadedTrig, setFileLoadedTrig] = useState(0);
   const [fileImportedTrig, setFileImportedTrig] = useState(0);
   const [macroOverrides, setMacroOverrides] = useState<Record<string, string>>({});
+  const [gridSize, setGridSize] = useState<number>(1);
+  const [snapToGrid, setSnapToGrid] = useState<boolean>(true);
+  const DRAG_END_DELAY = 80; //ms
 
   const clipboard = useRef<Widget[]>([]);
   const copiedSelectionBounds = useRef({ x: 0, y: 0, width: 0, height: 0 });
@@ -585,6 +591,73 @@ export function useWidgetManager() {
     [selectedWidgets, batchWidgetUpdate],
   );
 
+  const handleDragStop = (_e: RndDragEvent, d: DraggableData, w: Widget) => {
+    setIsDragging(false);
+    if (w.editableProperties.x?.value == d.x && w.editableProperties.y?.value == d.y) return;
+    updateWidgetProperties(w.id, {
+      x: ensureGridCoordinate(d.x, snapToGrid, gridSize),
+      y: ensureGridCoordinate(d.y, snapToGrid, gridSize),
+    });
+  };
+
+  const handleResizeStop = (ref: HTMLElement, position: Position, w: Widget) => {
+    setIsDragging(false);
+    const newWidth = ensureGridCoordinate(parseInt(ref.style.width), snapToGrid, gridSize);
+    const newHeight = ensureGridCoordinate(parseInt(ref.style.height), snapToGrid, gridSize);
+    const newX = ensureGridCoordinate(position.x, snapToGrid, gridSize);
+    const newY = ensureGridCoordinate(position.y, snapToGrid, gridSize);
+
+    if (
+      w.editableProperties.width?.value === newWidth &&
+      w.editableProperties.height?.value === newHeight
+    )
+      return;
+
+    updateWidgetProperties(w.id, { width: newWidth, height: newHeight, x: newX, y: newY });
+  };
+
+  const handleSelGroupResizeStop = (ref: HTMLElement, bounds: DOMRectLike, widgets: Widget[]) => {
+    setIsDragging(false);
+    const newGroupWidth = ref.offsetWidth;
+    const newGroupHeight = ref.offsetHeight;
+    const scaleX = newGroupWidth / bounds.width;
+    const scaleY = newGroupHeight / bounds.height;
+
+    const updates: MultiWidgetPropertyUpdates = {};
+    widgets.forEach((w) => {
+      const { width, height, x, y } = {
+        width: w.editableProperties.width!.value,
+        height: w.editableProperties.height!.value,
+        x: w.editableProperties.x!.value,
+        y: w.editableProperties.y!.value,
+      };
+      const relativeX = x - bounds.x;
+      const relativeY = y - bounds.y;
+      updates[w.id] = {
+        width: ensureGridCoordinate(width * scaleX, snapToGrid, gridSize),
+        height: ensureGridCoordinate(height * scaleY, snapToGrid, gridSize),
+        x: ensureGridCoordinate(bounds.x + relativeX * scaleX, snapToGrid, gridSize),
+        y: ensureGridCoordinate(bounds.y + relativeY * scaleY, snapToGrid, gridSize),
+      };
+    });
+    batchWidgetUpdate(updates);
+  };
+
+  const handleSelGroupDragStop = (dx: number, dy: number) => {
+    setTimeout(() => setIsDragging(false), DRAG_END_DELAY);
+    const updates: MultiWidgetPropertyUpdates = {};
+    selectedWidgets.forEach((widget) => {
+      const xProp = widget.editableProperties.x;
+      const yProp = widget.editableProperties.y;
+      if (!xProp || !yProp) return;
+      updates[widget.id] = {
+        x: ensureGridCoordinate(xProp.value + dx, snapToGrid, gridSize),
+        y: ensureGridCoordinate(yProp.value + dy, snapToGrid, gridSize),
+      };
+    });
+    batchWidgetUpdate(updates);
+  };
+
   /**
    * Undo the last editor state change.
    */
@@ -1068,11 +1141,24 @@ export function useWidgetManager() {
       snapshotEditModeMacros,
       restoreEditModeMacros,
       setMacroOverrides,
+      setIsDragging,
+      handleDragStop,
+      handleResizeStop,
+      handleSelGroupDragStop,
+      handleSelGroupResizeStop,
+      setGridSize,
+      setSnapToGrid,
+      gridSize,
+      snapToGrid,
+      isDragging,
     }),
     // Stable setState/useCallback refs are intentionally omitted.
     // Listing only the reactive state values.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
+      gridSize,
+      snapToGrid,
+      isDragging,
       editorWidgets,
       selectedWidgetIDs,
       editingWidgets,

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -19,7 +19,7 @@ import { GRID_ID, MAX_HISTORY } from "@src/constants/constants";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import { v4 as uuidv4 } from "uuid";
 import { notifyUser } from "@src/services/Notifications/Notification";
-import { substituteInStr } from "@src/utils/macros";
+import { substituteMacroInStr } from "@src/utils/macros";
 import { derivePVNames } from "@components/RulesDialog/ruleDialogUtils";
 import {
   createGroupWidget,
@@ -55,6 +55,7 @@ export function useWidgetManager() {
   const [selectedWidgetIDs, setSelectedWidgetIDs] = useState<string[]>([]);
   const [fileLoadedTrig, setFileLoadedTrig] = useState(0);
   const [fileImportedTrig, setFileImportedTrig] = useState(0);
+  const [macroOverrides, setMacroOverrides] = useState<Record<string, string>>({});
 
   const clipboard = useRef<Widget[]>([]);
   const copiedSelectionBounds = useRef({ x: 0, y: 0, width: 0, height: 0 });
@@ -920,27 +921,24 @@ export function useWidgetManager() {
   }, [updateWidgetProperties]);
 
   /**
-   * Macros to be substituted on pv names.
-   * In runtime mode, macroOverrides (computed by WidgetRenderer from fired rules)
-   * are merged on top of the GridZone's design-time macros so that annotatedEditorWidgets stays in sync.
+   * Macros to be substituted on pv names (design-time).
    */
-  const [macroOverrides, setMacroOverrides] = useState<Record<string, string>>({});
-  const baseMacros = getWidget(GRID_ID)?.editableProperties.macros?.value;
-  const macros = useMemo(
-    () =>
-      Object.keys(macroOverrides).length > 0
-        ? { ...(baseMacros ?? {}), ...macroOverrides }
-        : baseMacros,
-    [baseMacros, macroOverrides],
+  const baseGlobalMacros = useMemo(
+    () => getWidget(GRID_ID)?.editableProperties.macros?.value ?? {},
+    [getWidget],
   );
 
   /**
-   * Helper to substitute macros of the form $(NAME) in a PV string.
-   * If a macro key is not found in macros, the original macro text is kept.
+   * In runtime mode, macroOverrides (computed by WidgetRenderer from fired rules)
+   * are merged on top of the GridZone's design-time macros so that
+   * annotatedEditorWidgets stays in sync.
    */
-  const substituteMacros = useCallback(
-    (pv: string): string => (macros ? substituteInStr(pv, macros) : pv),
-    [macros],
+  const globalMacros = useMemo(
+    () =>
+      Object.keys(macroOverrides).length > 0
+        ? { ...baseGlobalMacros, ...macroOverrides }
+        : baseGlobalMacros,
+    [baseGlobalMacros, macroOverrides],
   );
 
   /**
@@ -948,13 +946,13 @@ export function useWidgetManager() {
    * macros or PV-name properties change. No save in history.
    */
   useEffect(() => {
-    const annotateWidget = (w: Widget): Widget => {
+    const addRuntimePVs = (w: Widget): Widget => {
       const pvName = w.editableProperties?.pvName?.value;
       const pvNames = w.editableProperties?.pvNames?.value;
 
-      const runtimePVName = pvName ? substituteMacros(pvName) : undefined;
-      const runtimePVNames = pvNames?.length ? pvNames.map(substituteMacros) : undefined;
-      const annotatedChildren = w.children?.map(annotateWidget);
+      const runtimePVName = pvName ? substituteMacroInStr(pvName, globalMacros) : undefined;
+      const runtimePVNames = pvNames?.map((name) => substituteMacroInStr(name, globalMacros));
+      const wRuntimeChildren = w.children?.map(addRuntimePVs);
 
       const pvNameUnchanged = runtimePVName === w.runtimePVName;
       const pvNamesUnchanged =
@@ -962,7 +960,7 @@ export function useWidgetManager() {
         (runtimePVNames?.length === w.runtimePVNames?.length &&
           runtimePVNames?.every((v, i) => v === w.runtimePVNames![i]));
       const childrenUnchanged =
-        !annotatedChildren || annotatedChildren.every((c, i) => c === w.children![i]);
+        !wRuntimeChildren || wRuntimeChildren.every((c, i) => c === w.children![i]);
 
       if (pvNameUnchanged && pvNamesUnchanged && childrenUnchanged) return w;
 
@@ -970,15 +968,15 @@ export function useWidgetManager() {
         ...w,
         ...(runtimePVName !== undefined ? { runtimePVName } : {}),
         ...(runtimePVNames !== undefined ? { runtimePVNames } : {}),
-        ...(annotatedChildren ? { children: annotatedChildren } : {}),
+        ...(wRuntimeChildren ? { children: wRuntimeChildren } : {}),
       };
     };
 
-    const annotated = editorWidgets.map(annotateWidget);
-    if (annotated.some((w, i) => w !== editorWidgets[i])) {
-      setEditorWidgets(annotated);
+    const withRuntime = editorWidgets.map(addRuntimePVs);
+    if (withRuntime.some((w, i) => w !== editorWidgets[i])) {
+      setEditorWidgets(withRuntime);
     }
-  }, [editorWidgets, substituteMacros]);
+  }, [editorWidgets, globalMacros]);
 
   /**
    * Flat deduplicated list of all resolved PV names that need WebSocket subscriptions:
@@ -992,13 +990,13 @@ export function useWidgetManager() {
         if (w.runtimePVNames) for (const pv of w.runtimePVNames) pvSet.add(pv);
         for (const rule of w.rules ?? []) {
           for (const pv of rule.pvNames) {
-            const substituted = substituteMacros(pv);
+            const substituted = substituteMacroInStr(pv, globalMacros);
             if (substituted) pvSet.add(substituted);
           }
           // Pre-subscribe pvName action targets so EpicsWS is ready before the rule fires
           const pvNameAction = rule.actions?.pvName;
           if (typeof pvNameAction === "string" && pvNameAction) {
-            const substituted = substituteMacros(pvNameAction);
+            const substituted = substituteMacroInStr(pvNameAction, globalMacros);
             if (substituted) pvSet.add(substituted);
           }
         }
@@ -1007,7 +1005,7 @@ export function useWidgetManager() {
     };
     collect(editorWidgets);
     return [...pvSet];
-  }, [editorWidgets, substituteMacros]);
+  }, [editorWidgets, globalMacros]);
 
   return useMemo(
     () => ({
@@ -1057,7 +1055,8 @@ export function useWidgetManager() {
       updateWidgetRules,
       batchUpdateWidgetRules,
       resolvedPVList,
-      macros,
+      baseGlobalMacros,
+      globalMacros,
       allWidgetIDs,
       widgetIdMap,
       formatWdgToExport,
@@ -1082,7 +1081,8 @@ export function useWidgetManager() {
       redoStack,
       selectedWidgets,
       resolvedPVList,
-      macros,
+      baseGlobalMacros,
+      globalMacros,
       allWidgetIDs,
       widgetIdMap,
       fileLoadedTrig,

--- a/src/context/widgetHelpers.ts
+++ b/src/context/widgetHelpers.ts
@@ -14,6 +14,14 @@ import type {
   PropertyValue,
 } from "@src/types/widgets";
 
+/** Make sure the given coordinate is aligned with grid if snapToGrid.
+ * Round returned coordinate to `gridDecimalPlaces` digits.
+ */
+export const ensureGridCoordinate = (coord: number, snapToGrid: boolean, gridSize: number) => {
+  const aligned = snapToGrid ? Math.round(coord / gridSize) * gridSize : coord;
+  return Math.round(aligned * ROUNDING_CONST) / ROUNDING_CONST;
+};
+
 /**
  * Deep clone a single widget including its editable properties and children recursively.
  * @param widget Widget to clone

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -60,6 +60,9 @@ export interface RuleCondition {
   value: string; // always string; engine coerces to number when both sides are numeric
 }
 
+//** Map with PropertyKeys affected and the new Values */
+export type RuleOverrides = Partial<Record<PropertyKey, PropertyValue>>;
+
 /**
  * A rule that overrides widget properties at runtime when its conditions are met.
  * Rules are evaluated in order; later rules win on same-property conflicts.
@@ -70,7 +73,7 @@ export interface Rule {
   pvNames: string[]; // PVs this rule subscribes to (for WS subscription)
   conditionLogic?: "AND" | "OR";
   conditions: RuleCondition[];
-  actions: Partial<Record<PropertyKey, PropertyValue>>;
+  actions: RuleOverrides;
 }
 
 /**

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -34,7 +34,7 @@ export function buildRuntimeMacros(
   macros["$(pvunits)"] = pvData?.display?.units ?? "";
   if (pvData?.value !== undefined)
     macros["$(pvvalue)"] = Array.isArray(pvData.value)
-      ? pvData.value.join(", ")
+      ? "pvvalue macro not supported for arrays"
       : String(pvData.value);
   else {
     macros["$(pvvalue)"] = "";

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -88,8 +88,7 @@ export function substituteTextProps(
 /**
  * Walks every widget in the tree (including nested children), evaluates their
  * rules against the current PV state, and aggregates any `globalMacros` action
- * values into a single merged map.  Called from the `usePVStore.subscribe()`
- * effect in WidgetRenderer; only runs in runtime mode.
+ * values into a single merged map.
  */
 export function collectGlobalMacroOverrides(
   widgets: Widget[],

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -88,16 +88,18 @@ export function substituteTextProps(
 /**
  * Walks every widget in the tree (including nested children), evaluates their
  * rules against the current PV state, and aggregates any `globalMacros` action
- * values into a single merged map.
+ * values into a single map.
  */
 export function collectGlobalMacroOverrides(
   widgets: Widget[],
   pvState: Record<string, PVData>,
   baseGlobalMacros: Record<string, string>,
 ): Record<string, string> {
-  let merged: Record<string, string> = {};
+  let overrides: Record<string, string> = {};
   for (const w of flattenWidgetTree(widgets)) {
     if (!w.rules?.length) continue;
+    const hasGlobMacroRule = w.rules.some((r) => r.actions.globalMacros !== undefined);
+    if (!hasGlobMacroRule) continue;
     const wPvName = w.runtimePVName;
     const wPvData = wPvName ? pvState[wPvName] : undefined;
     const wInternalMacros = buildRuntimeMacros(wPvName, wPvData);
@@ -108,8 +110,8 @@ export function collectGlobalMacroOverrides(
     const wRuleEvalMacros = wPvName ? { ...wMacros, "$(pvname)": wPvName } : wMacros;
     const wOverrides = evaluateRules(w.rules, pvState, wRuleEvalMacros);
     if (wOverrides.globalMacros && typeof wOverrides.globalMacros === "object") {
-      merged = { ...merged, ...(wOverrides.globalMacros as Record<string, string>) };
+      overrides = { ...overrides, ...(wOverrides.globalMacros as Record<string, string>) };
     }
   }
-  return merged;
+  return overrides;
 }

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -10,30 +10,35 @@ import { evaluateRules } from "./ruleEngine";
  * Substitute $(MACRO_NAME) patterns in a single string using a macros map.
  * Unresolved macros (no matching key) are left as-is.
  */
-export function substituteInStr(str: string, macros: Record<string, string>): string {
+export function substituteMacroInStr(str: string, macros: Record<string, string>): string {
+  if (!str.includes("$(")) return str; // skip regex search if str has no macros at all
   return str.replace(/\$\(([^)]+)\)/g, (match) => macros[match] ?? match);
 }
 
 /**
- * Build the built-in per-widget macro map from resolved PV data.
+ * Build the built-in per-widget macro map from runtime PV data.
  * Keys follow the same $(NAME) convention as user macros so they flow
- * through substituteInStr / substituteTextProps unchanged.
+ * through substituteMacroInStr / substituteTextProps unchanged.
+ * e.g.: $(pvname), $(pvdesc), $(pvvalue)
  *
  * @param substitutedPVName The widget's PV name after user macros are applied.
  * @param pvData            Resolved PV data for this widget (may be undefined).
  */
-export function buildInternalMacros(
+export function buildRuntimeMacros(
   substitutedPVName: string | undefined,
   pvData: PVData | undefined,
 ): Record<string, string> {
   const macros: Record<string, string> = {};
-  if (substitutedPVName) macros["$(pvname)"] = substitutedPVName;
-  if (pvData?.display?.description) macros["$(pvdesc)"] = pvData.display.description;
-  if (pvData?.display?.units) macros["$(pvunits)"] = pvData.display.units;
+  macros["$(pvname)"] = substitutedPVName ?? "Unknown PV name";
+  macros["$(pvdesc)"] = pvData?.display?.description ?? "";
+  macros["$(pvunits)"] = pvData?.display?.units ?? "";
   if (pvData?.value !== undefined)
     macros["$(pvvalue)"] = Array.isArray(pvData.value)
       ? pvData.value.join(", ")
       : String(pvData.value);
+  else {
+    macros["$(pvvalue)"] = "";
+  }
   return macros;
 }
 
@@ -57,7 +62,7 @@ export function substituteTextProps(
       continue;
     }
     if (prop.selType === "text" && typeof prop.value === "string") {
-      const substituted = substituteInStr(prop.value, macros);
+      const substituted = substituteMacroInStr(prop.value, macros);
       if (substituted !== prop.value) {
         resultRecord[key] = { ...prop, value: substituted };
         changed = true;
@@ -66,7 +71,7 @@ export function substituteTextProps(
       }
     } else if (prop.selType === "strList" && Array.isArray(prop.value)) {
       const original = prop.value;
-      const substituted = original.map((s) => substituteInStr(s, macros));
+      const substituted = original.map((s) => substituteMacroInStr(s, macros));
       if (substituted.some((s, i) => s !== original[i])) {
         resultRecord[key] = { ...prop, value: substituted };
         changed = true;
@@ -96,7 +101,7 @@ export function collectGlobalMacroOverrides(
     if (!w.rules?.length) continue;
     const wPvName = w.runtimePVName;
     const wPvData = wPvName ? pvState[wPvName] : undefined;
-    const wInternalMacros = buildInternalMacros(wPvName, wPvData);
+    const wInternalMacros = buildRuntimeMacros(wPvName, wPvData);
     const wMacros =
       Object.keys(wInternalMacros).length > 0
         ? { ...baseGlobalMacros, ...wInternalMacros }

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
+import { flattenWidgetTree } from "@src/context/widgetHelpers";
 import type { PVData } from "@src/types/epicsWS";
-import type { PropertyKey, WidgetProperties, WidgetProperty } from "@src/types/widgets";
+import type { PropertyKey, Widget, WidgetProperties, WidgetProperty } from "@src/types/widgets";
+import { evaluateRules } from "./ruleEngine";
 
 /**
  * Substitute $(MACRO_NAME) patterns in a single string using a macros map.
@@ -76,4 +78,34 @@ export function substituteTextProps(
     }
   }
   return changed ? result : props;
+}
+
+/**
+ * Walks every widget in the tree (including nested children), evaluates their
+ * rules against the current PV state, and aggregates any `globalMacros` action
+ * values into a single merged map.  Called from the `usePVStore.subscribe()`
+ * effect in WidgetRenderer; only runs in runtime mode.
+ */
+export function collectGlobalMacroOverrides(
+  widgets: Widget[],
+  pvState: Record<string, PVData>,
+  baseGlobalMacros: Record<string, string>,
+): Record<string, string> {
+  let merged: Record<string, string> = {};
+  for (const w of flattenWidgetTree(widgets)) {
+    if (!w.rules?.length) continue;
+    const wPvName = w.runtimePVName;
+    const wPvData = wPvName ? pvState[wPvName] : undefined;
+    const wInternalMacros = buildInternalMacros(wPvName, wPvData);
+    const wMacros =
+      Object.keys(wInternalMacros).length > 0
+        ? { ...baseGlobalMacros, ...wInternalMacros }
+        : baseGlobalMacros;
+    const wRuleEvalMacros = wPvName ? { ...wMacros, "$(pvname)": wPvName } : wMacros;
+    const wOverrides = evaluateRules(w.rules, pvState, wRuleEvalMacros);
+    if (wOverrides.globalMacros && typeof wOverrides.globalMacros === "object") {
+      merged = { ...merged, ...(wOverrides.globalMacros as Record<string, string>) };
+    }
+  }
+  return merged;
 }

--- a/src/utils/ruleEngine.ts
+++ b/src/utils/ruleEngine.ts
@@ -7,9 +7,11 @@ import type {
   RuleOperator,
   PropertyKey,
   PropertyValue,
+  Widget,
+  RuleOverrides,
 } from "@src/types/widgets";
 import type { PVData } from "@src/types/epicsWS";
-import { substituteInStr as substituteMacroStr } from "@src/utils/macros";
+import { substituteMacroInStr as substituteMacroStr } from "@src/utils/macros";
 
 /**
  * Evaluate a single condition against the current pvState.
@@ -103,8 +105,8 @@ export function evaluateRules(
   rules: Rule[],
   pvState: Record<string, PVData>,
   macros: Record<string, string> = {},
-): Partial<Record<PropertyKey, PropertyValue>> {
-  const overrides: Partial<Record<PropertyKey, PropertyValue>> = {};
+): RuleOverrides {
+  const overrides: RuleOverrides = {};
 
   for (const rule of rules) {
     if (evaluateRule(rule, pvState, macros)) {
@@ -124,4 +126,23 @@ export function evaluateRules(
   }
 
   return overrides;
+}
+
+export function applyRules(w: Widget, overrides: RuleOverrides): Widget {
+  return {
+    ...w,
+    editableProperties: Object.fromEntries(
+      Object.entries(w.editableProperties).map(([key, prop]) => {
+        const override = overrides[key as keyof RuleOverrides];
+        if (override === undefined) return [key, prop];
+        if (key === "macros" && typeof override === "object" && !Array.isArray(override)) {
+          return [
+            key,
+            { ...prop, value: { ...(prop.value as Record<string, string>), ...override } },
+          ];
+        }
+        return [key, { ...prop, value: override }];
+      }),
+    ) as typeof w.editableProperties,
+  };
 }


### PR DESCRIPTION
Some time ago, in the wrongful rush of delivering the first features, I let some sloppy code pass (mine and/or AI produced).
This PR is way bigger than a normal PR should be, but I'd rather do it all at once. 

I mostly am deleting code here, or moving parts with the purpose of making things easier to maintain and understand.

### Rule-driven macro substitutions
Most of the messy code was introduced when rules added the possibility of changing macros during runtime based on PV values.
There was a lot of indirection to handle that, and code was a bit scattered all around.  I now centralized that in a single place, and reduced the number of calls related to that.

### Widget renderer
- On the widget renderer there were some stability checks that avoided the return of a new object instance, but it added little to performance and a lot against readability, so I dropped it as well. For now, such micro-optimization is not necessary, and I favor clarity and readability at this stage. 
This change highlights (again) a problem in the plots: the layout (zoom, pan, etc) resets on PV updates. This is happening because the layout is using effect hooks - this was a decision in the beginning, but there is no such need. A simple `useRef` should be enough - these will be fixed in the next PR.

- Move drag/resize handlers away from renderer, that was scope creep: they belong to WidgetManager.tsx and were moved there now.