### PR TITLE
Improve plots

### DIFF
--- a/src/components/Widgets/GraphXY/GraphXYComp.tsx
+++ b/src/components/Widgets/GraphXY/GraphXYComp.tsx
@@ -2,7 +2,7 @@
 // GraphXY widget — X vs Y scatter/line plot for WEISS
 // Contributed by Elmaddin Guliyev
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
@@ -38,40 +38,34 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
   // Ring buffers: one per PV
   const valueBuffers = useRef<Record<string, number[]>>({});
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
-  const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
-  const [layout, setLayout] = useState<Partial<Plotly.Layout>>({});
+  const plotData = useRef<Plotly.Data[]>([{}]);
+  const xLabel = pvNames.length > 0 ? pvNames[0] : "X";
 
-  // Build traces
-  useEffect(() => {
-    // Edit-mode preview
-    if (inEditMode) {
-      valueBuffers.current = {};
-      const previewPvs = pvNames.length > 0 ? pvNames : ["X PV", "Y PV"];
-      if (previewPvs.length >= 2) {
-        const xPreview = [1, 2, 3, 4, 5, 6, 7, 8];
-        const traces: Plotly.Data[] = [];
-        for (let i = 1; i < previewPvs.length; i++) {
-          const yPreview = xPreview.map((v) => v * (1 + i * 0.3) + Math.sin(v * i) * 2);
-          traces.push({
-            x: xPreview,
-            y: yPreview,
-            type: "scatter",
-            mode: plotLineStyle as Plotly.PlotData["mode"],
-            line: { color: lineColors?.[i - 1] ?? "auto" },
-            marker: { size: 6 },
-            name: `${previewPvs[0]} vs ${previewPvs[i]}`,
-          });
-        }
-        setPlotData(traces);
+  const buildPreviewTraces = () => {
+    plotData.current = [{}];
+    valueBuffers.current = {};
+    const previewPvs = pvNames.length > 0 ? pvNames : ["X PV", "Y PV"];
+    if (previewPvs.length >= 2) {
+      const xPreview = [1, 2, 3, 4, 5, 6, 7, 8];
+      for (let i = 1; i < previewPvs.length; i++) {
+        const yPreview = xPreview.map((v) => v * (1 + i * 0.3) + Math.sin(v * i) * 2);
+        plotData.current.push({
+          x: xPreview,
+          y: yPreview,
+          type: "scatter",
+          mode: plotLineStyle as Plotly.PlotData["mode"],
+          line: { color: lineColors?.[i - 1] ?? "auto" },
+          marker: { size: 6 },
+          name: `${previewPvs[0]} vs ${previewPvs[i]}`,
+        });
       }
-      return;
     }
+  };
 
-    if (!data.multiPvData || pvNames.length < 2) return;
-
-    // Check for new data
+  const buildRuntimeTraces = () => {
+    if (!pvData) return;
     let updated = false;
-    for (const [pvName, pv] of Object.entries(data.multiPvData)) {
+    for (const [pvName, pv] of Object.entries(pvData)) {
       const newValTs = pv.timeStamp;
       const oldValTs = prevPvTimestamps.current[pvName];
       if (newValTs === oldValTs) continue;
@@ -89,7 +83,7 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
     if (!updated) return;
 
     const xPvName = pvNames[0];
-    const xPv = data.multiPvData[xPvName];
+    const xPv = pvData[xPvName];
     if (!xPv) return;
 
     // X data: either from buffer (scalar) or array
@@ -104,10 +98,9 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
     if (!xData || xData.length === 0) return;
 
     // Build Y traces
-    const traces: Plotly.Data[] = [];
     for (let i = 1; i < pvNames.length; i++) {
       const yPvName = pvNames[i];
-      const yPv = data.multiPvData[yPvName];
+      const yPv = pvData[yPvName];
       if (!yPv) continue;
 
       const yVal = yPv.value;
@@ -123,7 +116,7 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
       // Align lengths
       const len = Math.min(xData.length, yData.length);
 
-      traces.push({
+      plotData.current.push({
         x: xData.slice(-len),
         y: yData.slice(-len),
         type: "scatter",
@@ -133,65 +126,66 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
         name: `${yPvName}`,
       });
     }
+  };
 
-    setPlotData(traces);
-  }, [inEditMode, data.multiPvData, bufferSize, plotLineStyle, lineColors, pvNames]);
+  if (inEditMode) {
+    buildPreviewTraces();
+  } else {
+    buildRuntimeTraces();
+  }
 
   // Layout
-  useEffect(() => {
-    const xLabel = pvNames.length > 0 ? pvNames[0] : "X";
-    setLayout({
+  const layout: Partial<Plotly.Layout> = {
+    title: {
+      text: p.plotTitle?.value ?? "",
+      font: {
+        family: p.fontFamily?.value,
+        size: p.fontSize?.value,
+        weight: p.fontBold?.value ? 800 : 0,
+        style: p.fontItalic?.value ? "italic" : "normal",
+        lineposition: p.fontUnderlined?.value ? "under" : "none",
+        color: p.textColor?.value,
+      },
+      x: titleXpos,
+      y: titleYpos,
+    },
+    xaxis: {
       title: {
-        text: p.plotTitle?.value ?? "",
+        text: p.xAxisTitle?.value ?? xLabel,
         font: {
           family: p.fontFamily?.value,
-          size: p.fontSize?.value,
-          weight: p.fontBold?.value ? 800 : 0,
-          style: p.fontItalic?.value ? "italic" : "normal",
-          lineposition: p.fontUnderlined?.value ? "under" : "none",
-          color: p.textColor?.value,
-        },
-        x: titleXpos,
-        y: titleYpos,
-      },
-      xaxis: {
-        title: {
-          text: p.xAxisTitle?.value ?? xLabel,
-          font: {
-            family: p.fontFamily?.value,
-            size: (p.fontSize?.value ?? 12) - 2,
-            color: COLORS.lightGray,
-          },
-        },
-        type: "linear",
-      },
-      yaxis: {
-        type: p.logscaleY?.value ? "log" : "linear",
-        title: {
-          text: p.yAxisTitle?.value ?? "",
-          font: {
-            family: p.fontFamily?.value,
-            size: (p.fontSize?.value ?? 12) - 2,
-            color: COLORS.lightGray,
-          },
+          size: (p.fontSize?.value ?? 12) - 2,
+          color: COLORS.lightGray,
         },
       },
-      paper_bgcolor: p.backgroundColor?.value,
-      plot_bgcolor: p.backgroundColor?.value,
-      margin: { b: 45, l: 45, t: 50, r: 30 },
-      width: p.width?.value,
-      height: p.height?.value,
-      showlegend: p.showLegend?.value,
-      legend: {
-        orientation: "h",
-        x: 1,
-        xanchor: "right",
-        y: 0.975,
-        bgcolor: "00000000",
+      type: "linear",
+    },
+    yaxis: {
+      type: p.logscaleY?.value ? "log" : "linear",
+      title: {
+        text: p.yAxisTitle?.value ?? "",
+        font: {
+          family: p.fontFamily?.value,
+          size: (p.fontSize?.value ?? 12) - 2,
+          color: COLORS.lightGray,
+        },
       },
-      uirevision: String(inEditMode),
-    });
-  }, [p, pvNames, inEditMode, titleXpos, titleYpos]);
+    },
+    paper_bgcolor: p.backgroundColor?.value,
+    plot_bgcolor: p.backgroundColor?.value,
+    margin: { b: 45, l: 45, t: 50, r: 30 },
+    width: p.width?.value,
+    height: p.height?.value,
+    showlegend: p.showLegend?.value,
+    legend: {
+      orientation: "h",
+      x: 1,
+      xanchor: "right",
+      y: 0.975,
+      bgcolor: "00000000",
+    },
+    uirevision: String(inEditMode),
+  };
 
   return (
     <AlarmBorder alarmData={alarmData} enable={p.alarmBorder?.value}>
@@ -208,7 +202,7 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
         }}
       >
         <Plot
-          data={plotData}
+          data={plotData.current}
           layout={layout}
           config={{
             responsive: true,

--- a/src/components/Widgets/GraphY/GraphYComp.tsx
+++ b/src/components/Widgets/GraphY/GraphYComp.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
@@ -27,131 +27,124 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const titleYpos = textVAlign == "bottom" ? 0.05 : textVAlign == "middle" ? 0.5 : 0.95;
 
   const valueBuffers = useRef<Record<string, number[]>>({});
-  const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
-  const [layout, setLayout] = useState<Partial<Plotly.Layout>>({});
+  const plotData = useRef<Plotly.Data[]>([{}]);
+  const previewPvs = pvNames ?? ["<pvname>"];
 
-  // build traces
-  useEffect(() => {
-    if (inEditMode) {
-      valueBuffers.current = {};
-      const previewPvs = pvNames ?? ["<pvname>"];
-      const previewTraces = previewPvs.map((pvName, idx) => {
-        const base = idx * 0.5;
-        const y = [base, base + 3, base + 2, base + 5];
-        return {
-          y,
-          type: "scatter",
-          mode: plotLineStyle,
-          line: { color: lineColors?.[idx] ?? "auto" },
-          name: pvName,
-        } as Plotly.Data;
-      });
-      setPlotData(previewTraces);
-      return;
-    }
+  const buildPreviewTraces = () => {
+    plotData.current = [{}];
+    plotData.current = previewPvs.map((pvName, idx) => {
+      const base = idx * 0.5;
+      const y = [base, base + 3, base + 2, base + 5];
+      return {
+        y,
+        type: "scatter",
+        mode: plotLineStyle,
+        line: { color: lineColors?.[idx] ?? "auto" },
+        name: pvName,
+      } as Plotly.Data;
+    });
+  };
 
-    if (!multiPvData) return;
-    let updated = false;
-
-    for (const [pvName, pv] of Object.entries(multiPvData)) {
-      const newValTs = pv.timeStamp;
-      const oldValTs = prevPvTimestamps.current[pvName];
-      if (newValTs === oldValTs) continue;
-      prevPvTimestamps.current[pvName] = newValTs;
-      updated = true;
-      const newVal = pv.value;
-      if (typeof newVal === "number") {
-        if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
-        const buf = valueBuffers.current[pvName];
-        buf.push(newVal);
-        if (buf.length > bufferSize) buf.shift();
+  const buildRuntimeTraces = () => {
+    plotData.current = [{}];
+    if (multiPvData) {
+      for (const [pvName, pv] of Object.entries(multiPvData)) {
+        const newValTs = pv.timeStamp;
+        const oldValTs = prevPvTimestamps.current[pvName];
+        if (newValTs === oldValTs) continue;
+        prevPvTimestamps.current[pvName] = newValTs;
+        const newVal = pv.value;
+        if (typeof newVal === "number") {
+          if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
+          const buf = valueBuffers.current[pvName];
+          buf.push(newVal);
+          if (buf.length > bufferSize) buf.shift();
+        }
       }
+      plotData.current = Object.entries(multiPvData)
+        .map(([pvName, pv]) => {
+          const pvIdx = pvNames?.indexOf(pvName) ?? -1;
+          if (pvIdx === -1) return null;
+
+          const v = pv.value;
+          const y =
+            typeof v === "number"
+              ? [...(valueBuffers.current[pvName] ?? [])]
+              : Array.isArray(v)
+                ? [...v]
+                : null;
+
+          if (!y) return null;
+
+          return {
+            y,
+            type: "scatter",
+            mode: plotLineStyle,
+            line: { color: lineColors?.[pvIdx] },
+            name: pvName,
+          } as Plotly.Data;
+        })
+        .filter((t): t is Plotly.Data => t !== null);
     }
+  };
 
-    if (!updated) return;
+  if (inEditMode) {
+    buildPreviewTraces();
+  } else {
+    buildRuntimeTraces();
+  }
 
-    const traces = Object.entries(multiPvData)
-      .map(([pvName, pv]) => {
-        const pvIdx = pvNames?.indexOf(pvName) ?? -1;
-        if (pvIdx === -1) return null;
-
-        const v = pv.value;
-        const y =
-          typeof v === "number"
-            ? [...(valueBuffers.current[pvName] ?? [])]
-            : Array.isArray(v)
-              ? [...v]
-              : null;
-
-        if (!y) return null;
-
-        return {
-          y,
-          type: "scatter",
-          mode: plotLineStyle,
-          line: { color: lineColors?.[pvIdx] },
-          name: pvName,
-        } as Plotly.Data;
-      })
-      .filter((t): t is Plotly.Data => t !== null);
-
-    setPlotData(traces);
-  }, [inEditMode, multiPvData, bufferSize, plotLineStyle, lineColors, pvNames]);
-
-  useEffect(() => {
-    setLayout({
+  const layout: Partial<Plotly.Layout> = {
+    title: {
+      text: p.plotTitle?.value,
+      font: {
+        family: p.fontFamily?.value,
+        size: p.fontSize?.value,
+        weight: p.fontBold?.value ? 800 : 0,
+        style: p.fontItalic?.value ? "italic" : "normal",
+        lineposition: p.fontUnderlined?.value ? "under" : "none",
+        color: p.textColor?.value,
+      },
+      x: titleXpos,
+      y: titleYpos,
+    },
+    xaxis: {
       title: {
-        text: p.plotTitle?.value,
+        text: p.xAxisTitle?.value,
         font: {
           family: p.fontFamily?.value,
-          size: p.fontSize?.value,
-          weight: p.fontBold?.value ? 800 : 0,
-          style: p.fontItalic?.value ? "italic" : "normal",
-          lineposition: p.fontUnderlined?.value ? "under" : "none",
-          color: p.textColor?.value,
-        },
-        x: titleXpos,
-        y: titleYpos,
-      },
-      xaxis: {
-        title: {
-          text: p.xAxisTitle?.value,
-          font: {
-            family: p.fontFamily?.value,
-            size: (p.fontSize?.value ?? 12) - 2,
-            color: COLORS.lightGray,
-          },
+          size: (p.fontSize?.value ?? 12) - 2,
+          color: COLORS.lightGray,
         },
       },
-      yaxis: {
-        type: p.logscaleY?.value ? "log" : "linear",
-        title: {
-          text: p.yAxisTitle?.value,
-          font: {
-            family: p.fontFamily?.value,
-            size: (p.fontSize?.value ?? 12) - 2,
-            color: COLORS.lightGray,
-          },
+    },
+    yaxis: {
+      type: p.logscaleY?.value ? "log" : "linear",
+      title: {
+        text: p.yAxisTitle?.value,
+        font: {
+          family: p.fontFamily?.value,
+          size: (p.fontSize?.value ?? 12) - 2,
+          color: COLORS.lightGray,
         },
       },
-      paper_bgcolor: p.backgroundColor?.value,
-      plot_bgcolor: p.backgroundColor?.value,
-      margin: { b: 35, l: 35, t: 50, r: 30 },
-      width: p.width?.value,
-      height: p.height?.value,
-      showlegend: p.showLegend?.value,
-      legend: {
-        orientation: "h",
-        x: 1,
-        xanchor: "right",
-        y: 0.975,
-        bgcolor: "00000000",
-      },
-
-      uirevision: String(inEditMode),
-    });
-  }, [p, pvNames, inEditMode, titleXpos, titleYpos]);
+    },
+    paper_bgcolor: p.backgroundColor!.value,
+    plot_bgcolor: p.backgroundColor!.value,
+    margin: { b: 35, l: 35, t: 50, r: 30 },
+    width: p.width!.value,
+    height: p.height!.value,
+    showlegend: p.showLegend!.value,
+    legend: {
+      orientation: "h",
+      x: 1,
+      xanchor: "right",
+      y: 0.975,
+      bgcolor: "00000000",
+    },
+    uirevision: String(inEditMode),
+  };
 
   return (
     <AlarmBorder alarmData={alarmData} enable={p.alarmBorder?.value}>
@@ -168,7 +161,7 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
         }}
       >
         <Plot
-          data={plotData}
+          data={plotData.current}
           layout={layout}
           config={{
             responsive: true,

--- a/src/components/Widgets/Histogram/HistogramComp.tsx
+++ b/src/components/Widgets/Histogram/HistogramComp.tsx
@@ -2,7 +2,7 @@
 // Histogram widget for WEISS
 // Contributed by Elmaddin Guliyev
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
@@ -25,30 +25,26 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const valueBuffer = useRef<number[]>([]);
   const prevTimestamp = useRef<TimeStamp | undefined>(undefined);
-  const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
-  const [layout, setLayout] = useState<Partial<Plotly.Layout>>({});
+  const plotData = useRef<Plotly.Data[]>([{}]);
 
-  useEffect(() => {
-    if (inEditMode) {
-      valueBuffer.current = [];
-      const preview: number[] = [];
-      for (let i = 0; i < 200; i++) {
-        preview.push(
-          50 + 15 * Math.sqrt(-2 * Math.log(Math.random())) * Math.cos(2 * Math.PI * Math.random()),
-        );
-      }
-      setPlotData([
-        {
-          x: preview,
-          type: "histogram",
-          marker: { color: barColor },
-        } as Plotly.Data,
-      ]);
-      return;
+  const buildPreviewTraces = () => {
+    valueBuffer.current = [];
+    const nPoints = 200;
+    const preview: number[] = [];
+    for (let i = 0; i < nPoints; i++) {
+      preview.push(50 + 15 * Math.sqrt(-2 * Math.log(i)) * Math.cos(2 * Math.PI * i));
     }
+    plotData.current = [
+      {
+        x: preview,
+        type: "histogram",
+        marker: { color: barColor },
+      } as Plotly.Data,
+    ];
+  };
 
+  const buildRuntimeTraces = () => {
     if (!pvData) return;
-
     const newTs = pvData.timeStamp;
     if (newTs === prevTimestamp.current) return;
     prevTimestamp.current = newTs;
@@ -56,73 +52,77 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
     const value = pvData.value;
 
     if (Array.isArray(value)) {
-      setPlotData([
+      plotData.current = [
         {
           x: [...(value as number[])],
           type: "histogram",
           marker: { color: barColor },
         } as Plotly.Data,
-      ]);
+      ];
     } else if (typeof value === "number") {
       valueBuffer.current.push(value);
       if (valueBuffer.current.length > bufferSize) {
         valueBuffer.current = valueBuffer.current.slice(-bufferSize);
       }
-      setPlotData([
+      plotData.current = [
         {
           x: [...valueBuffer.current],
           type: "histogram",
           marker: { color: barColor },
         } as Plotly.Data,
-      ]);
+      ];
     }
-  }, [inEditMode, pvData, bufferSize, barColor]);
+  };
 
-  useEffect(() => {
-    setLayout({
+  if (inEditMode) {
+    buildPreviewTraces();
+  } else {
+    buildRuntimeTraces();
+  }
+
+  const layout: Partial<Plotly.Layout> = {
+    title: {
+      text: p.plotTitle?.value ?? "",
+      font: {
+        family: p.fontFamily?.value,
+        size: p.fontSize?.value,
+        weight: p.fontBold?.value ? 800 : 0,
+        style: p.fontItalic?.value ? "italic" : "normal",
+        lineposition: p.fontUnderlined?.value ? "under" : "none",
+        color: p.textColor?.value,
+      },
+      x: titleXpos,
+      y: titleYpos,
+    },
+    xaxis: {
       title: {
-        text: p.plotTitle?.value ?? "",
+        text: p.xAxisTitle?.value ?? "",
         font: {
           family: p.fontFamily?.value,
-          size: p.fontSize?.value,
-          weight: p.fontBold?.value ? 800 : 0,
-          style: p.fontItalic?.value ? "italic" : "normal",
-          lineposition: p.fontUnderlined?.value ? "under" : "none",
-          color: p.textColor?.value,
-        },
-        x: titleXpos,
-        y: titleYpos,
-      },
-      xaxis: {
-        title: {
-          text: p.xAxisTitle?.value ?? "",
-          font: {
-            family: p.fontFamily?.value,
-            size: (p.fontSize?.value ?? 12) - 2,
-            color: COLORS.lightGray,
-          },
+          size: (p.fontSize?.value ?? 12) - 2,
+          color: COLORS.lightGray,
         },
       },
-      yaxis: {
-        title: {
-          text: p.yAxisTitle?.value ?? "Count",
-          font: {
-            family: p.fontFamily?.value,
-            size: (p.fontSize?.value ?? 12) - 2,
-            color: COLORS.lightGray,
-          },
+    },
+    yaxis: {
+      title: {
+        text: p.yAxisTitle?.value ?? "Count",
+        font: {
+          family: p.fontFamily?.value,
+          size: (p.fontSize?.value ?? 12) - 2,
+          color: COLORS.lightGray,
         },
       },
-      bargap: 0.05,
-      paper_bgcolor: p.backgroundColor?.value,
-      plot_bgcolor: p.backgroundColor?.value,
-      margin: { b: 45, l: 45, t: 50, r: 30 },
-      width: p.width?.value,
-      height: p.height?.value,
-      showlegend: false,
-      uirevision: String(inEditMode),
-    });
-  }, [p, inEditMode, titleXpos, titleYpos]);
+    },
+    bargap: 0.05,
+    paper_bgcolor: p.backgroundColor?.value,
+    plot_bgcolor: p.backgroundColor?.value,
+    margin: { b: 45, l: 45, t: 50, r: 30 },
+    width: p.width?.value,
+    height: p.height?.value,
+    showlegend: false,
+    uirevision: String(inEditMode),
+  };
 
   return (
     <AlarmBorder alarmData={alarmData} enable={p.alarmBorder?.value}>
@@ -139,7 +139,7 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         }}
       >
         <Plot
-          data={plotData}
+          data={plotData.current}
           layout={layout}
           config={{
             responsive: true,

--- a/src/components/Widgets/Histogram/HistogramComp.tsx
+++ b/src/components/Widgets/Histogram/HistogramComp.tsx
@@ -2,7 +2,7 @@
 // Histogram widget for WEISS
 // Contributed by Elmaddin Guliyev
 
-import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
@@ -27,13 +27,27 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
   const prevTimestamp = useRef<TimeStamp | undefined>(undefined);
   const plotData = useRef<Plotly.Data[]>([{}]);
 
-  const buildPreviewTraces = () => {
-    valueBuffer.current = [];
-    const nPoints = 200;
-    const preview: number[] = [];
-    for (let i = 0; i < nPoints; i++) {
-      preview.push(50 + 15 * Math.sqrt(-2 * Math.log(i)) * Math.cos(2 * Math.PI * i));
+  // build (once) a normal distribution for preview
+  const preview = useMemo(() => {
+    const minValue = 0;
+    const maxValue = 100;
+    const mean = 50;
+    const stdDev = 15;
+    const sampleScale = 100;
+    const data: number[] = [];
+    for (let x = minValue; x <= maxValue; x++) {
+      const normalizedDistance = (x - mean) / stdDev;
+      const pdf = Math.exp(-0.5 * normalizedDistance ** 2);
+      const count = Math.round(pdf * sampleScale);
+
+      for (let i = 0; i < count; i++) {
+        data.push(x);
+      }
     }
+    return data;
+  }, []);
+
+  const buildPreviewTraces = () => {
     plotData.current = [
       {
         x: preview,


### PR DESCRIPTION
I first designed the plots to change using `useEffect` hooks triggered by data changing, but now this is not needed since we already know that the components will only re-render if new data arrived for their PVs.

Remove `useEffect` hooks and use `useRef` instead where applicable.
Propagate same changes in all 3 plot components:
- GraphY
- GraphXY
- Histogram

For the Histogram, also stop generating random data, and use always a fixed distribution instead. Seeing the preview data changing during edit mode every time we open the OPI is not necessary and may confuse the users.

FYI: @egguliyev 