### PR TITLE
mount roles.example.toml file

### DIFF
--- a/backend/api/roles.example.toml
+++ b/backend/api/roles.example.toml
@@ -11,8 +11,8 @@
 # Changes take effect either after the server restarts or after calling:
 #   POST /api/v1/auth/admin/reload-roles   (requires developer role)
 
-[roles]
-developers = [
-    # "person1@example.com",
-    # "person2@example.com",
-]
+# [roles]
+# developers = [
+#    "person1@example.com",
+#    "person2@example.com",
+# ]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -39,7 +39,7 @@ services:
     volumes:
       - ./backend/api:/app/api
       - storage:/app/storage
-      - ${ROLES_CONFIG_FILE:-./roles.toml}:/config/roles.toml:ro
+      - ${ROLES_CONFIG_FILE:-./backend/roles.example.toml}:/config/roles.toml:ro
     image: weiss-api-dev:${DOCKER_TAG:-latest}
     container_name: weiss-api-dev
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       context: ./backend/api
     volumes:
       - storage:/app/storage
-      - ${ROLES_CONFIG_FILE:-./roles.toml}:/config/roles.toml:ro
+      - ${ROLES_CONFIG_FILE:-./backend/roles.example.toml}:/config/roles.toml:ro
     image: weiss-api:${DOCKER_TAG:-latest}
     container_name: weiss-api
     ports:


### PR DESCRIPTION
Do this to prevent Docker from creating a roles.toml folder