### PR TITLE
fix: persist navigation state when switching tabs

### DIFF
--- a/src/components/EditorSidebar/EditorSidebar.tsx
+++ b/src/components/EditorSidebar/EditorSidebar.tsx
@@ -228,13 +228,15 @@ const EditorSidebar: React.FC = () => {
 
         {/* Content */}
         <div style={{ flex: "1 1 auto", overflowY: "auto" }}>
-          {tabIndex === EditorTab.EDIT ? (
+          <div style={{ display: tabIndex === EditorTab.EDIT ? "block" : "none" }}>
             <PropertyNavigator />
-          ) : tabIndex === EditorTab.LAYERS ? (
+          </div>
+          <div style={{ display: tabIndex === EditorTab.LAYERS ? "block" : "none" }}>
             <WidgetTree />
-          ) : (
+          </div>
+          <div style={{ display: tabIndex === EditorTab.NAVIGATE ? "block" : "none" }}>
             <ProjectsTab />
-          )}
+          </div>
         </div>
 
         {/* Tabs */}


### PR DESCRIPTION
File navigator was always resetting state when changing tabs, which is annoying.
Fix that by keeping it always mounted and just omit when necessary