### PR TITLE
Add padding to buttons, change LabelFromPV default

### DIFF
--- a/src/components/Widgets/ActionButton/ActionButtonComp.tsx
+++ b/src/components/Widgets/ActionButton/ActionButtonComp.tsx
@@ -56,7 +56,7 @@ const ActionButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
           textTransform: "none",
           minWidth: 0,
           minHeight: 0,
-          padding: 0,
+          padding: 0.5,
           pointerEvents: inEditMode ? "none" : "auto",
           overflow: "hidden",
         }}

--- a/src/components/Widgets/NavigationButton/NavigationButtonComp.tsx
+++ b/src/components/Widgets/NavigationButton/NavigationButtonComp.tsx
@@ -64,7 +64,7 @@ const NavigationButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
         textTransform: "none",
         minWidth: 0,
         minHeight: 0,
-        padding: 0,
+        padding: 0.5,
         pointerEvents: inEditMode ? "none" : "auto",
         overflow: "hidden",
       }}

--- a/src/components/Widgets/SelectionBox/SelectionBox.ts
+++ b/src/components/Widgets/SelectionBox/SelectionBox.ts
@@ -23,6 +23,6 @@ export const SelectionBox: WidgetDefinition = {
     disabled: PROPERTY_SCHEMAS.disabled,
     alarmBorder: PROPERTY_SCHEMAS.alarmBorder,
     enumChoices: PROPERTY_SCHEMAS.enumChoices,
-    labelFromPV: PROPERTY_SCHEMAS.labelFromPV,
+    labelFromPV: { ...PROPERTY_SCHEMAS.labelFromPV, value: true },
   },
 };

--- a/src/components/Widgets/ToggleButton/ToggleButtonComp.tsx
+++ b/src/components/Widgets/ToggleButton/ToggleButtonComp.tsx
@@ -87,7 +87,7 @@ const ToggleButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
           textTransform: "none",
           minWidth: 0,
           minHeight: 0,
-          padding: 0,
+          padding: 0.5,
           overflow: "hidden",
         }}
         disableRipple={inEditMode || !validValue}

--- a/src/types/widgetProperties.ts
+++ b/src/types/widgetProperties.ts
@@ -70,7 +70,7 @@ export const PROPERTY_SCHEMAS = {
   unitsFromPV:     defineProp({ selType: "boolean", label: "Units from PV", value: true as boolean, category: "EPICS" }),
   units:           defineProp({ selType: "text", label: "Units", value: "" as string, category: "EPICS" }),
   alarmBorder:     defineProp({ selType: "boolean", label: "Alarm border", value: true as boolean, category: "EPICS" }),
-  labelFromPV:     defineProp({ selType: "boolean", label: "Label(s) from PV", value: true as boolean, category: "EPICS" }),
+  labelFromPV:     defineProp({ selType: "boolean", label: "Label(s) from PV", value: false as boolean, category: "EPICS" }),
   actionValue:     defineProp({ selType: "text", label: "Action Value", value: 1 as number | string, category: "EPICS" }),
   // BitIndicators
   horizontal:      defineProp({ selType: "boolean", label: "Horizontal", value: false, category: "Layout" }),


### PR DESCRIPTION
- Buttons content were too close to the edges - add a small padding.
- Start with labelFromPV false, override to true for SelectionBox.