### PR TITLE
fix navigation macro forwarding

### DIFF
--- a/src/components/Widgets/NavigationButton/NavigationButtonComp.tsx
+++ b/src/components/Widgets/NavigationButton/NavigationButtonComp.tsx
@@ -26,8 +26,8 @@ const NavigationButtonComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   useEffect(() => {
     // whenever the selected file changes, check if this button was the cause.
-    // If so, replace runtime navigation macros so the next screen starts with
-    // the button-provided macro set as its only forwarded navigation macros.
+    // If so, forward the current runtime macro context and append this
+    // button-provided macros on top.
     if (inEditMode) return;
     if (!selectedFile) return;
     if (!clicked.current) return;

--- a/src/context/useWidgetManager.ts
+++ b/src/context/useWidgetManager.ts
@@ -19,7 +19,7 @@ import { GRID_ID, MAX_HISTORY } from "@src/constants/constants";
 import WidgetRegistry from "@components/WidgetRegistry/WidgetRegistry";
 import { v4 as uuidv4 } from "uuid";
 import { notifyUser } from "@src/services/Notifications/Notification";
-import { substituteMacroInStr } from "@src/utils/macros";
+import { composeForwardNavigationMacros, substituteMacroInStr } from "@src/utils/macros";
 import { derivePVNames } from "@components/RulesDialog/ruleDialogUtils";
 import {
   createGroupWidget,
@@ -1016,15 +1016,6 @@ export function useWidgetManager() {
   }, []);
 
   /**
-   * Forward runtime macros from a navigation action.
-   * Existing runtime layers are replaced so opening the next screen starts clean.
-   */
-  const forwardNavigationMacros = useCallback((macros: Record<string, string>) => {
-    setNavMacroOverrides(macros);
-    setRuleMacroOverrides({});
-  }, []);
-
-  /**
    * Macros to be substituted on pv names (design-time).
    */
   const baseGlobalMacros = useMemo(
@@ -1039,6 +1030,18 @@ export function useWidgetManager() {
         ? { ...baseGlobalMacros, ...navMacroOverrides }
         : baseGlobalMacros,
     [baseGlobalMacros, navMacroOverrides],
+  );
+
+  /**
+   * Forward runtime macros from a navigation action.
+   * Runtime base macros are forwarded and button macros are appended on top.
+   * Duplicate keys from the button win only when they resolve to concrete values.
+   */
+  const forwardNavigationMacros = useCallback(
+    (macros: Record<string, string>) => {
+      setNavMacroOverrides(composeForwardNavigationMacros(runtimeBaseMacros, macros));
+    },
+    [runtimeBaseMacros],
   );
 
   /**

--- a/src/utils/macros.ts
+++ b/src/utils/macros.ts
@@ -6,6 +6,18 @@ import type { PVData } from "@src/types/epicsWS";
 import type { PropertyKey, Widget, WidgetProperties, WidgetProperty } from "@src/types/widgets";
 import { evaluateRules } from "./ruleEngine";
 
+const MACRO_TOKEN_PATTERN = /^\$\([^)]+\)$/;
+
+function normalizeMacroKey(key: string): string {
+  const trimmed = key.trim();
+  if (!trimmed) return trimmed;
+  return MACRO_TOKEN_PATTERN.test(trimmed) ? trimmed : `$(${trimmed})`;
+}
+
+function isConcreteMacroValue(value: string): boolean {
+  return !value.includes("$(");
+}
+
 /**
  * Substitute $(MACRO_NAME) patterns in a single string using a macros map.
  * Unresolved macros (no matching key) are left as-is.
@@ -13,6 +25,41 @@ import { evaluateRules } from "./ruleEngine";
 export function substituteMacroInStr(str: string, macros: Record<string, string>): string {
   if (!str.includes("$(")) return str; // skip regex search if str has no macros at all
   return str.replace(/\$\(([^)]+)\)/g, (match) => macros[match] ?? match);
+}
+
+/**
+ * Build the forwarded navigation macro layer from the current runtime base macros
+ * and a clicked button macro map.
+ *
+ * - Existing runtime macros are forwarded by default.
+ * - New button entries override duplicates when they resolve to concrete values.
+ * - If a new value remains unresolved (e.g. "$(A)"), it does not clobber an
+ *   already concrete value for that key.
+ */
+export function composeForwardNavigationMacros(
+  runtimeBaseMacros: Record<string, string>,
+  buttonMacros: Record<string, string>,
+): Record<string, string> {
+  const forwarded: Record<string, string> = { ...runtimeBaseMacros };
+
+  for (const [rawKey, rawValue] of Object.entries(buttonMacros)) {
+    const normalizedKey = normalizeMacroKey(rawKey);
+    if (!normalizedKey) continue;
+
+    const previousValue = forwarded[normalizedKey];
+    const resolvedValue = substituteMacroInStr(rawValue, forwarded);
+    const unresolvedIncoming = !isConcreteMacroValue(resolvedValue);
+    const hadConcreteValue =
+      typeof previousValue === "string" && isConcreteMacroValue(previousValue);
+
+    if (unresolvedIncoming && hadConcreteValue) {
+      continue;
+    }
+
+    forwarded[normalizedKey] = resolvedValue;
+  }
+
+  return forwarded;
 }
 
 /**


### PR DESCRIPTION
Instead of replacing, append macros forwarded by navigation button, replacing only where macro key is the same.