### PR TITLE
Graph timestamps

### DIFF
--- a/src/components/Widgets/GraphXY/GraphXYComp.tsx
+++ b/src/components/Widgets/GraphXY/GraphXYComp.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
-import type { TimeStamp } from "@src/types/epicsWS";
+import type { MultiPvData, TimeStamp } from "@src/types/epicsWS";
 import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
 
@@ -91,17 +91,16 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const buildRuntimeTraces = () => {
     if (!pvData) return;
-    let updated = false;
-    for (const [pvName, pv] of Object.entries(pvData)) {
+
+    const updateBuffer = (pvName: string, pv: MultiPvData[string]) => {
       const newValTs = pv.timeStamp;
       const oldValTs = prevPvTimestamps.current[pvName];
       const sameTs =
         oldValTs &&
         oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
         oldValTs.nanoseconds === newValTs.nanoseconds;
-      if (sameTs) continue;
+      if (sameTs) return;
       prevPvTimestamps.current[pvName] = newValTs;
-      updated = true;
       const newVal = pv.value;
       if (typeof newVal === "number") {
         if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
@@ -109,13 +108,12 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
         buf.push([toEpochMillis(newValTs), newVal]);
         if (buf.length > bufferSize) buf.shift();
       }
-    }
-
-    if (!updated) return;
+    };
 
     const xPvName = pvNames[0];
     const xPv = pvData[xPvName];
     if (!xPv) return;
+    updateBuffer(xPvName, xPv);
 
     const xVal = xPv.value;
     const xData =
@@ -132,6 +130,7 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
       const yPvName = pvNames[i];
       const yPv = pvData[yPvName];
       if (!yPv) continue;
+      updateBuffer(yPvName, yPv);
 
       const yVal = yPv.value;
       const yData =

--- a/src/components/Widgets/GraphXY/GraphXYComp.tsx
+++ b/src/components/Widgets/GraphXY/GraphXYComp.tsx
@@ -2,7 +2,7 @@
 // GraphXY widget — X vs Y scatter/line plot for WEISS
 // Contributed by Elmaddin Guliyev
 
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
@@ -10,13 +10,17 @@ import type { TimeStamp } from "@src/types/epicsWS";
 import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
 
+type ScalarPoint = [number, number];
+
+const toEpochMillis = (ts: TimeStamp): number =>
+  ts.secondsPastEpoch * 1000 + Math.trunc(ts.nanoseconds / 1_000_000);
+
 /**
  * GraphXY — Plots PV values against each other.
  *
  * When two PVs are provided, the first is used as X and the second as Y.
  * When more than two are provided, the first PV is the shared X axis
  * and each subsequent PV is a separate Y trace.
- * When a single PV contains an array, it is plotted as Y with index as X.
  */
 const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { inEditMode } = useUIContext();
@@ -36,10 +40,35 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const titleYpos = textVAlign === "bottom" ? 0.05 : textVAlign === "middle" ? 0.5 : 0.95;
 
   // Ring buffers: one per PV
-  const valueBuffers = useRef<Record<string, number[]>>({});
+  const valueBuffers = useRef<Record<string, ScalarPoint[]>>({});
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
-  const plotData = useRef<Plotly.Data[]>([{}]);
+  const plotData = useRef<Plotly.Data[]>([]);
   const xLabel = pvNames.length > 0 ? pvNames[0] : "X";
+  const awaitingFreshDataRef = useRef(false);
+
+  useEffect(() => {
+    // Since browser may keep page inactive when losing focus, reset the runtime buffers
+    // for scalar PVs to avoid showing a false "gap" in the data when the page is re-focused.
+    const resetRuntimeBuffers = () => {
+      valueBuffers.current = {};
+      prevPvTimestamps.current = {};
+      awaitingFreshDataRef.current = true;
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        resetRuntimeBuffers();
+      }
+    };
+
+    window.addEventListener("focus", resetRuntimeBuffers);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", resetRuntimeBuffers);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
 
   const buildPreviewTraces = () => {
     plotData.current = [{}];
@@ -75,7 +104,7 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
       if (typeof newVal === "number") {
         if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
         const buf = valueBuffers.current[pvName];
-        buf.push(newVal);
+        buf.push([toEpochMillis(newValTs), newVal]);
         if (buf.length > bufferSize) buf.shift();
       }
     }
@@ -86,37 +115,35 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
     const xPv = pvData[xPvName];
     if (!xPv) return;
 
-    // X data: either from buffer (scalar) or array
     const xVal = xPv.value;
-    const xData: number[] | null =
+    const xData =
       typeof xVal === "number"
-        ? [...(valueBuffers.current[xPvName] ?? [])]
+        ? (valueBuffers.current[xPvName] ?? []).map(([, v]) => v)
         : Array.isArray(xVal)
           ? [...(xVal as number[])]
           : null;
 
     if (!xData || xData.length === 0) return;
 
-    // Build Y traces
+    const newTraces: Plotly.Data[] = [];
     for (let i = 1; i < pvNames.length; i++) {
       const yPvName = pvNames[i];
       const yPv = pvData[yPvName];
       if (!yPv) continue;
 
       const yVal = yPv.value;
-      const yData: number[] | null =
+      const yData =
         typeof yVal === "number"
-          ? [...(valueBuffers.current[yPvName] ?? [])]
+          ? (valueBuffers.current[yPvName] ?? []).map(([, v]) => v)
           : Array.isArray(yVal)
             ? [...(yVal as number[])]
             : null;
 
       if (!yData || yData.length === 0) continue;
 
-      // Align lengths
       const len = Math.min(xData.length, yData.length);
 
-      plotData.current.push({
+      newTraces.push({
         x: xData.slice(-len),
         y: yData.slice(-len),
         type: "scatter",
@@ -125,6 +152,10 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
         marker: { size: 5 },
         name: `${yPvName}`,
       });
+    }
+
+    if (newTraces.length > 0) {
+      plotData.current = newTraces;
     }
   };
 

--- a/src/components/Widgets/GraphXY/GraphXYComp.tsx
+++ b/src/components/Widgets/GraphXY/GraphXYComp.tsx
@@ -44,7 +44,6 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
   const plotData = useRef<Plotly.Data[]>([]);
   const xLabel = pvNames.length > 0 ? pvNames[0] : "X";
-  const awaitingFreshDataRef = useRef(false);
 
   useEffect(() => {
     // Since browser may keep page inactive when losing focus, reset the runtime buffers
@@ -52,7 +51,6 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
     const resetRuntimeBuffers = () => {
       valueBuffers.current = {};
       prevPvTimestamps.current = {};
-      awaitingFreshDataRef.current = true;
     };
 
     const handleVisibilityChange = () => {
@@ -97,7 +95,11 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
     for (const [pvName, pv] of Object.entries(pvData)) {
       const newValTs = pv.timeStamp;
       const oldValTs = prevPvTimestamps.current[pvName];
-      if (newValTs === oldValTs) continue;
+      const sameTs =
+        oldValTs &&
+        oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
+        oldValTs.nanoseconds === newValTs.nanoseconds;
+      if (sameTs) continue;
       prevPvTimestamps.current[pvName] = newValTs;
       updated = true;
       const newVal = pv.value;

--- a/src/components/Widgets/GraphY/GraphYComp.tsx
+++ b/src/components/Widgets/GraphY/GraphYComp.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 André Favoto
 
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
@@ -34,6 +34,31 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
   const plotData = useRef<Plotly.Data[]>([{}]);
   const previewPvs = pvNames ?? ["<pvname>"];
+  const awaitingFreshDataRef = useRef(false);
+
+  useEffect(() => {
+    // Since browser may keep page inactive when losing focus, reset the runtime buffers
+    // for scalar PVs to avoid showing a false "gap" in the data when the page is re-focused.
+    const resetRuntimeBuffers = () => {
+      valueBuffers.current = {};
+      prevPvTimestamps.current = {};
+      awaitingFreshDataRef.current = true;
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        resetRuntimeBuffers();
+      }
+    };
+
+    window.addEventListener("focus", resetRuntimeBuffers);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", resetRuntimeBuffers);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
 
   const buildPreviewTraces = () => {
     plotData.current = [{}];

--- a/src/components/Widgets/GraphY/GraphYComp.tsx
+++ b/src/components/Widgets/GraphY/GraphYComp.tsx
@@ -19,12 +19,11 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const p = data.editableProperties;
   const pvData = data.multiPvData ?? {};
   const alarmData = Object.values(pvData)
-    .map((p) => p.alarm)
+    .map((d) => d.alarm)
     .filter((a) => a !== undefined);
   const lineColors = p.lineColors?.value;
   const pvNames = p.pvNames?.value;
   const bufferSize = p.plotBufferSize?.value ?? 50;
-  const multiPvData = data.multiPvData;
   const plotLineStyle = p.plotLineStyle?.value ?? "lines";
   const textHAlign = p.textHAlign?.value;
   const textVAlign = p.textVAlign?.value;
@@ -34,7 +33,6 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
   const plotData = useRef<Plotly.Data[]>([{}]);
   const previewPvs = pvNames ?? ["<pvname>"];
-  const awaitingFreshDataRef = useRef(false);
 
   useEffect(() => {
     // Since browser may keep page inactive when losing focus, reset the runtime buffers
@@ -42,7 +40,6 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
     const resetRuntimeBuffers = () => {
       valueBuffers.current = {};
       prevPvTimestamps.current = {};
-      awaitingFreshDataRef.current = true;
     };
 
     const handleVisibilityChange = () => {
@@ -77,14 +74,13 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const isScalarOnlyRuntimeData =
     !inEditMode &&
-    multiPvData &&
-    Object.keys(multiPvData).length > 0 &&
-    Object.values(multiPvData).every((pv) => typeof pv.value === "number");
+    pvData &&
+    Object.keys(pvData).length > 0 &&
+    Object.values(pvData).every((pv) => typeof pv.value === "number");
 
   const buildRuntimeTraces = () => {
-    plotData.current = [{}];
-    if (multiPvData) {
-      for (const [pvName, pv] of Object.entries(multiPvData)) {
+    if (pvData) {
+      for (const [pvName, pv] of Object.entries(pvData)) {
         const newValTs = pv.timeStamp;
         const oldValTs = prevPvTimestamps.current[pvName];
         const sameTs =
@@ -101,7 +97,7 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
           if (buf.length > bufferSize) buf.shift();
         }
       }
-      plotData.current = Object.entries(multiPvData)
+      plotData.current = Object.entries(pvData)
         .map(([pvName, pv]) => {
           const pvIdx = pvNames?.indexOf(pvName) ?? -1;
           if (pvIdx === -1) return null;

--- a/src/components/Widgets/GraphY/GraphYComp.tsx
+++ b/src/components/Widgets/GraphY/GraphYComp.tsx
@@ -9,6 +9,11 @@ import type { TimeStamp } from "@src/types/epicsWS";
 import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
 
+type ScalarPoint = [number, number];
+
+const toEpochMillis = (ts: TimeStamp): number =>
+  ts.secondsPastEpoch * 1000 + Math.trunc(ts.nanoseconds / 1_000_000);
+
 const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { inEditMode } = useUIContext();
   const p = data.editableProperties;
@@ -25,8 +30,7 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const textVAlign = p.textVAlign?.value;
   const titleXpos = textHAlign == "left" ? 0.05 : textHAlign == "right" ? 0.95 : 0.5;
   const titleYpos = textVAlign == "bottom" ? 0.05 : textVAlign == "middle" ? 0.5 : 0.95;
-
-  const valueBuffers = useRef<Record<string, number[]>>({});
+  const valueBuffers = useRef<Record<string, ScalarPoint[]>>({});
   const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
   const plotData = useRef<Plotly.Data[]>([{}]);
   const previewPvs = pvNames ?? ["<pvname>"];
@@ -46,19 +50,29 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
     });
   };
 
+  const isScalarOnlyRuntimeData =
+    !inEditMode &&
+    multiPvData &&
+    Object.keys(multiPvData).length > 0 &&
+    Object.values(multiPvData).every((pv) => typeof pv.value === "number");
+
   const buildRuntimeTraces = () => {
     plotData.current = [{}];
     if (multiPvData) {
       for (const [pvName, pv] of Object.entries(multiPvData)) {
         const newValTs = pv.timeStamp;
         const oldValTs = prevPvTimestamps.current[pvName];
-        if (newValTs === oldValTs) continue;
+        const sameTs =
+          oldValTs &&
+          oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
+          oldValTs.nanoseconds === newValTs.nanoseconds;
+        if (sameTs) continue;
         prevPvTimestamps.current[pvName] = newValTs;
         const newVal = pv.value;
         if (typeof newVal === "number") {
           if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
           const buf = valueBuffers.current[pvName];
-          buf.push(newVal);
+          buf.push([toEpochMillis(newValTs), newVal]);
           if (buf.length > bufferSize) buf.shift();
         }
       }
@@ -68,22 +82,30 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
           if (pvIdx === -1) return null;
 
           const v = pv.value;
-          const y =
-            typeof v === "number"
-              ? [...(valueBuffers.current[pvName] ?? [])]
-              : Array.isArray(v)
-                ? [...v]
-                : null;
 
-          if (!y) return null;
+          if (typeof v === "number") {
+            const buf = valueBuffers.current[pvName] ?? [];
+            return {
+              x: buf.map(([t]) => t),
+              y: buf.map(([, val]) => val),
+              type: "scatter",
+              mode: plotLineStyle,
+              line: { color: lineColors?.[pvIdx] },
+              name: pvName,
+            } as Plotly.Data;
+          }
 
-          return {
-            y,
-            type: "scatter",
-            mode: plotLineStyle,
-            line: { color: lineColors?.[pvIdx] },
-            name: pvName,
-          } as Plotly.Data;
+          if (Array.isArray(v)) {
+            return {
+              y: [...v],
+              type: "scatter",
+              mode: plotLineStyle,
+              line: { color: lineColors?.[pvIdx] },
+              name: pvName,
+            } as Plotly.Data;
+          }
+
+          return null;
         })
         .filter((t): t is Plotly.Data => t !== null);
     }
@@ -110,6 +132,7 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
       y: titleYpos,
     },
     xaxis: {
+      type: isScalarOnlyRuntimeData ? "date" : undefined,
       title: {
         text: p.xAxisTitle?.value,
         font: {

--- a/src/components/Widgets/GraphY/GraphYComp.tsx
+++ b/src/components/Widgets/GraphY/GraphYComp.tsx
@@ -79,15 +79,18 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
     Object.values(pvData).every((pv) => typeof pv.value === "number");
 
   const buildRuntimeTraces = () => {
-    if (pvData) {
-      for (const [pvName, pv] of Object.entries(pvData)) {
-        const newValTs = pv.timeStamp;
-        const oldValTs = prevPvTimestamps.current[pvName];
-        const sameTs =
-          oldValTs &&
-          oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
-          oldValTs.nanoseconds === newValTs.nanoseconds;
-        if (sameTs) continue;
+    if (!pvData) return;
+
+    const traces: (Plotly.Data & { __pvIdx: number })[] = [];
+
+    for (const [pvName, pv] of Object.entries(pvData)) {
+      const newValTs = pv.timeStamp;
+      const oldValTs = prevPvTimestamps.current[pvName];
+      const sameTs =
+        oldValTs &&
+        oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
+        oldValTs.nanoseconds === newValTs.nanoseconds;
+      if (!sameTs) {
         prevPvTimestamps.current[pvName] = newValTs;
         const newVal = pv.value;
         if (typeof newVal === "number") {
@@ -97,39 +100,38 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
           if (buf.length > bufferSize) buf.shift();
         }
       }
-      plotData.current = Object.entries(pvData)
-        .map(([pvName, pv]) => {
-          const pvIdx = pvNames?.indexOf(pvName) ?? -1;
-          if (pvIdx === -1) return null;
 
-          const v = pv.value;
+      const pvIdx = pvNames?.indexOf(pvName) ?? -1;
+      if (pvIdx === -1) continue;
 
-          if (typeof v === "number") {
-            const buf = valueBuffers.current[pvName] ?? [];
-            return {
-              x: buf.map(([t]) => t),
-              y: buf.map(([, val]) => val),
-              type: "scatter",
-              mode: plotLineStyle,
-              line: { color: lineColors?.[pvIdx] },
-              name: pvName,
-            } as Plotly.Data;
-          }
+      const v = pv.value;
 
-          if (Array.isArray(v)) {
-            return {
-              y: [...v],
-              type: "scatter",
-              mode: plotLineStyle,
-              line: { color: lineColors?.[pvIdx] },
-              name: pvName,
-            } as Plotly.Data;
-          }
-
-          return null;
-        })
-        .filter((t): t is Plotly.Data => t !== null);
+      if (typeof v === "number") {
+        const buf = valueBuffers.current[pvName] ?? [];
+        traces.push({
+          x: buf.map(([t]) => t),
+          y: buf.map(([, val]) => val),
+          type: "scatter",
+          mode: plotLineStyle as Plotly.PlotData["mode"],
+          line: { color: lineColors?.[pvIdx] },
+          name: pvName,
+          __pvIdx: pvIdx,
+        });
+      } else if (Array.isArray(v)) {
+        traces.push({
+          y: [...v],
+          type: "scatter",
+          mode: plotLineStyle as Plotly.PlotData["mode"],
+          line: { color: lineColors?.[pvIdx] },
+          name: pvName,
+          __pvIdx: pvIdx,
+        });
+      }
     }
+
+    plotData.current = traces
+      .sort((a, b) => a.__pvIdx - b.__pvIdx)
+      .map(({ __pvIdx, ...trace }) => trace);
   };
 
   if (inEditMode) {


### PR DESCRIPTION
Two main changes and one fix:

1 - Use timestamps from PV as X axis (only if value plotted is a scalar);
2 - Reset scalar plots if screen loses focus completely (user leaves tab).
Reason: If the screen is un-focused, the browser stops rendering the content. When screen is opened again, the plot starts from where it stopped, creating a fake "gap" on the data. Resetting the plots if render stops at some point is a quick fix for that. A more robust fix may be needed at some point.

Fix GraphXY creating multiple traces when using scalars.

Closes #177