### PR TITLE
Plots: move local buffers to shared utility

### DIFF
--- a/src/components/Widgets/GraphXY/GraphXYComp.tsx
+++ b/src/components/Widgets/GraphXY/GraphXYComp.tsx
@@ -6,14 +6,11 @@ import React, { useEffect, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
-import type { MultiPvData, TimeStamp } from "@src/types/epicsWS";
+import { getPVHistory, registerPVHistory } from "@src/utils/historyBuffers";
 import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
 
 type ScalarPoint = [number, number];
-
-const toEpochMillis = (ts: TimeStamp): number =>
-  ts.secondsPastEpoch * 1000 + Math.trunc(ts.nanoseconds / 1_000_000);
 
 /**
  * GraphXY — Plots PV values against each other.
@@ -40,37 +37,21 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const titleYpos = textVAlign === "bottom" ? 0.05 : textVAlign === "middle" ? 0.5 : 0.95;
 
   // Ring buffers: one per PV
-  const valueBuffers = useRef<Record<string, ScalarPoint[]>>({});
-  const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
   const plotData = useRef<Plotly.Data[]>([]);
   const xLabel = pvNames.length > 0 ? pvNames[0] : "X";
 
+  // Only accumulate scalar history for PVs that actually carry scalar values.
+  const scalarPvNames = pvNames.filter((pv) => typeof pvData[pv]?.value === "number");
+  const scalarPvNamesKey = scalarPvNames.join(",");
   useEffect(() => {
-    // Since browser may keep page inactive when losing focus, reset the runtime buffers
-    // for scalar PVs to avoid showing a false "gap" in the data when the page is re-focused.
-    const resetRuntimeBuffers = () => {
-      valueBuffers.current = {};
-      prevPvTimestamps.current = {};
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== "visible") {
-        resetRuntimeBuffers();
-      }
-    };
-
-    window.addEventListener("focus", resetRuntimeBuffers);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener("focus", resetRuntimeBuffers);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
+    if (inEditMode || !scalarPvNames.length) return;
+    const unregisters = scalarPvNames.map((pv) => registerPVHistory(pv, bufferSize));
+    return () => unregisters.forEach((unregister) => unregister());
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scalarPvNamesKey is the stable identity for scalarPvNames
+  }, [inEditMode, scalarPvNamesKey, bufferSize]);
 
   const buildPreviewTraces = () => {
     plotData.current = [{}];
-    valueBuffers.current = {};
     const previewPvs = pvNames.length > 0 ? pvNames : ["X PV", "Y PV"];
     if (previewPvs.length >= 2) {
       const xPreview = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -92,33 +73,17 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const buildRuntimeTraces = () => {
     if (!pvData) return;
 
-    const updateBuffer = (pvName: string, pv: MultiPvData[string]) => {
-      const newValTs = pv.timeStamp;
-      const oldValTs = prevPvTimestamps.current[pvName];
-      const sameTs =
-        oldValTs &&
-        oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
-        oldValTs.nanoseconds === newValTs.nanoseconds;
-      if (sameTs) return;
-      prevPvTimestamps.current[pvName] = newValTs;
-      const newVal = pv.value;
-      if (typeof newVal === "number") {
-        if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
-        const buf = valueBuffers.current[pvName];
-        buf.push([toEpochMillis(newValTs), newVal]);
-        if (buf.length > bufferSize) buf.shift();
-      }
-    };
+    // Lossless history buffer: accumulated on every WS message, independent of render throttling.
+    const getBuffer = (pvName: string): ScalarPoint[] => getPVHistory(pvName).slice(-bufferSize);
 
     const xPvName = pvNames[0];
     const xPv = pvData[xPvName];
     if (!xPv) return;
-    updateBuffer(xPvName, xPv);
 
     const xVal = xPv.value;
     const xData =
       typeof xVal === "number"
-        ? (valueBuffers.current[xPvName] ?? []).map(([, v]) => v)
+        ? getBuffer(xPvName).map(([, v]) => v)
         : Array.isArray(xVal)
           ? [...(xVal as number[])]
           : null;
@@ -130,12 +95,11 @@ const GraphXYComp: React.FC<WidgetUpdate> = ({ data }) => {
       const yPvName = pvNames[i];
       const yPv = pvData[yPvName];
       if (!yPv) continue;
-      updateBuffer(yPvName, yPv);
 
       const yVal = yPv.value;
       const yData =
         typeof yVal === "number"
-          ? (valueBuffers.current[yPvName] ?? []).map(([, v]) => v)
+          ? getBuffer(yPvName).map(([, v]) => v)
           : Array.isArray(yVal)
             ? [...(yVal as number[])]
             : null;

--- a/src/components/Widgets/GraphY/GraphYComp.tsx
+++ b/src/components/Widgets/GraphY/GraphYComp.tsx
@@ -5,14 +5,9 @@ import React, { useEffect, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
-import type { TimeStamp } from "@src/types/epicsWS";
+import { getPVHistory, registerPVHistory } from "@src/utils/historyBuffers";
 import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
-
-type ScalarPoint = [number, number];
-
-const toEpochMillis = (ts: TimeStamp): number =>
-  ts.secondsPastEpoch * 1000 + Math.trunc(ts.nanoseconds / 1_000_000);
 
 const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const { inEditMode } = useUIContext();
@@ -29,33 +24,18 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
   const textVAlign = p.textVAlign?.value;
   const titleXpos = textHAlign == "left" ? 0.05 : textHAlign == "right" ? 0.95 : 0.5;
   const titleYpos = textVAlign == "bottom" ? 0.05 : textVAlign == "middle" ? 0.5 : 0.95;
-  const valueBuffers = useRef<Record<string, ScalarPoint[]>>({});
-  const prevPvTimestamps = useRef<Record<string, TimeStamp>>({});
   const plotData = useRef<Plotly.Data[]>([{}]);
   const previewPvs = pvNames ?? ["<pvname>"];
 
+  // If PV carries only scalar values, request a buffer from PVStore
+  const scalarPvNames = pvNames?.filter((pv) => typeof pvData[pv]?.value === "number") ?? [];
+  const scalarPvNamesKey = scalarPvNames.join(",");
   useEffect(() => {
-    // Since browser may keep page inactive when losing focus, reset the runtime buffers
-    // for scalar PVs to avoid showing a false "gap" in the data when the page is re-focused.
-    const resetRuntimeBuffers = () => {
-      valueBuffers.current = {};
-      prevPvTimestamps.current = {};
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== "visible") {
-        resetRuntimeBuffers();
-      }
-    };
-
-    window.addEventListener("focus", resetRuntimeBuffers);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener("focus", resetRuntimeBuffers);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
+    if (inEditMode || !scalarPvNames.length) return;
+    const unregisters = scalarPvNames.map((pv) => registerPVHistory(pv, bufferSize));
+    return () => unregisters.forEach((unregister) => unregister());
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scalarPvNamesKey is the stable identity for scalarPvNames
+  }, [inEditMode, scalarPvNamesKey, bufferSize]);
 
   const buildPreviewTraces = () => {
     plotData.current = [{}];
@@ -84,30 +64,13 @@ const GraphYComp: React.FC<WidgetUpdate> = ({ data }) => {
     const traces: (Plotly.Data & { __pvIdx: number })[] = [];
 
     for (const [pvName, pv] of Object.entries(pvData)) {
-      const newValTs = pv.timeStamp;
-      const oldValTs = prevPvTimestamps.current[pvName];
-      const sameTs =
-        oldValTs &&
-        oldValTs.secondsPastEpoch === newValTs.secondsPastEpoch &&
-        oldValTs.nanoseconds === newValTs.nanoseconds;
-      if (!sameTs) {
-        prevPvTimestamps.current[pvName] = newValTs;
-        const newVal = pv.value;
-        if (typeof newVal === "number") {
-          if (!valueBuffers.current[pvName]) valueBuffers.current[pvName] = [];
-          const buf = valueBuffers.current[pvName];
-          buf.push([toEpochMillis(newValTs), newVal]);
-          if (buf.length > bufferSize) buf.shift();
-        }
-      }
-
       const pvIdx = pvNames?.indexOf(pvName) ?? -1;
       if (pvIdx === -1) continue;
 
       const v = pv.value;
 
       if (typeof v === "number") {
-        const buf = valueBuffers.current[pvName] ?? [];
+        const buf = getPVHistory(pvName).slice(-bufferSize);
         traces.push({
           x: buf.map(([t]) => t),
           y: buf.map(([, val]) => val),

--- a/src/components/Widgets/Histogram/HistogramComp.tsx
+++ b/src/components/Widgets/Histogram/HistogramComp.tsx
@@ -2,11 +2,11 @@
 // Histogram widget for WEISS
 // Contributed by Elmaddin Guliyev
 
-import React, { useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import type { WidgetUpdate } from "@src/types/widgets";
 import Plot from "react-plotly.js";
 import { COLORS } from "@src/constants/constants";
-import type { TimeStamp } from "@src/types/epicsWS";
+import { getPVHistory, registerPVHistory } from "@src/utils/historyBuffers";
 import AlarmBorder from "@src/components/AlarmBorder/AlarmBorder";
 import { useUIContext } from "@src/context/useUIContext";
 
@@ -24,8 +24,15 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
   const titleYpos = textVAlign === "bottom" ? 0.05 : textVAlign === "middle" ? 0.5 : 0.95;
 
   const valueBuffer = useRef<number[]>([]);
-  const prevTimestamp = useRef<TimeStamp | undefined>(undefined);
   const plotData = useRef<Plotly.Data[]>([{}]);
+
+  // Only accumulate scalar history for the PV this histogram actually needs.
+  const pvName = pvData?.pv;
+  const isScalar = typeof pvData?.value === "number";
+  useEffect(() => {
+    if (inEditMode || !pvName || !isScalar) return;
+    return registerPVHistory(pvName, bufferSize);
+  }, [inEditMode, pvName, isScalar, bufferSize]);
 
   // build (once) a normal distribution for preview
   const preview = useMemo(() => {
@@ -59,10 +66,6 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
 
   const buildRuntimeTraces = () => {
     if (!pvData) return;
-    const newTs = pvData.timeStamp;
-    if (newTs === prevTimestamp.current) return;
-    prevTimestamp.current = newTs;
-
     const value = pvData.value;
 
     if (Array.isArray(value)) {
@@ -74,10 +77,10 @@ const HistogramComp: React.FC<WidgetUpdate> = ({ data }) => {
         } as Plotly.Data,
       ];
     } else if (typeof value === "number") {
-      valueBuffer.current.push(value);
-      if (valueBuffer.current.length > bufferSize) {
-        valueBuffer.current = valueBuffer.current.slice(-bufferSize);
-      }
+      // Lossless history buffer: accumulated on every WS message, independent of render throttling.
+      valueBuffer.current = getPVHistory(pvData.pv)
+        .slice(-bufferSize)
+        .map(([, v]) => v);
       plotData.current = [
         {
           x: [...valueBuffer.current],

--- a/src/context/useEpicsWS.ts
+++ b/src/context/useEpicsWS.ts
@@ -6,6 +6,7 @@ import { WSClient } from "@src/services/WSClient/WSClient";
 import type { PVData, PVValue, WSMessage } from "@src/types/epicsWS";
 import { WS_URL } from "@src/constants/constants";
 import { usePVStore } from "@src/services/pvStore";
+import { pushPVHistory, clearPVHistory } from "@src/utils/historyBuffers";
 
 /**
  * Hook that manages a WebSocket session to the PV WebSocket.
@@ -49,15 +50,22 @@ export default function useEpicsWS(resolvedPVList: string[]) {
 
   /**
    * Handles incoming WebSocket messages.
+   *
    * Merges partial/sticky metadata fields into the per-frame accumulator.
    * The actual Zustand store write is deferred to the next animation frame so
    * that multiple messages arriving in the same frame are batched into one
    * React re-render cycle.
+   * In case of scalar PVs that have been registered for buffering (plots), push
+   * the sample into the history buffer independently of rAF batching so that
+   * the history is always up to date even if the widget is not re-rendering.
    */
   const onMessage = useCallback((msg: WSMessage) => {
     if (!subscribedRef.current.has(msg.pv)) {
       console.warn(`received message from unsolicited PV: ${msg.pv}`);
       return;
+    }
+    if (typeof msg.value === "number" && msg.timeStamp) {
+      pushPVHistory(msg.pv, msg.timeStamp, msg.value);
     }
     pendingPVsRef.current[msg.pv] = buildPVData(msg);
     rafHandleRef.current ??= requestAnimationFrame(() => {
@@ -103,6 +111,7 @@ export default function useEpicsWS(resolvedPVList: string[]) {
     if (toRemove.length > 0) {
       ws.current.unsubscribe(toRemove);
       usePVStore.getState().removePVs(toRemove);
+      clearPVHistory(toRemove);
     }
     subscribedRef.current = current;
   }, [resolvedPVList, wsConnected]);
@@ -122,6 +131,7 @@ export default function useEpicsWS(resolvedPVList: string[]) {
     pendingPVsRef.current = {};
     setWSConnected(false);
     usePVStore.getState().clearPVs();
+    clearPVHistory();
   }, [setWSConnected]);
 
   /**

--- a/src/utils/historyBuffers.tsx
+++ b/src/utils/historyBuffers.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 André Favoto
+
+import type { TimeStamp } from "@src/types/epicsWS";
+
+/** A single scalar sample: epoch-millis timestamp + value. */
+export type ScalarPoint = [number, number];
+
+export const toEpochMillis = (ts: TimeStamp): number =>
+  ts.secondsPastEpoch * 1000 + Math.trunc(ts.nanoseconds / 1_000_000);
+
+/**
+ * Ring buffers of scalar PV history, keyed by PV name.
+ * Buffering only happens for PVs a widget has explicitly registered interest in
+ * via `registerPVHistory`. This is mostly used by plot widgets reading from scalar
+ * PVs, which need to accumulate a history of samples for rendering.
+ */
+const historyBuffers: Record<string, ScalarPoint[]> = {};
+/** Requested buffer sizes per PV, keyed by subscriber token; capacity is the max across all subscribers. */
+const historySubscribers: Record<string, Map<symbol, number>> = {};
+
+function recomputeBufCapacity(pv: string): void {
+  const subs = historySubscribers[pv];
+  if (!subs || subs.size === 0) {
+    delete historyBuffers[pv];
+    delete historySubscribers[pv];
+    return;
+  }
+  const capacity = Math.max(...subs.values());
+  const buf = historyBuffers[pv];
+  if (buf && buf.length > capacity) historyBuffers[pv] = buf.slice(-capacity);
+}
+
+/**
+ * Registers interest in buffering a PV's scalar history, up to `bufferSize` samples.
+ * Returns an unregister function that must be called on cleanup (e.g. widget unmount).
+ * Multiple subscribers to the same PV are supported; the buffer capacity is the
+ * largest `bufferSize` requested by any current subscriber.
+ */
+export function registerPVHistory(pv: string, bufferSize: number): () => void {
+  const token = Symbol();
+  const subs = historySubscribers[pv] ?? (historySubscribers[pv] = new Map());
+  subs.set(token, bufferSize);
+  historyBuffers[pv] ??= [];
+  recomputeBufCapacity(pv);
+  return () => {
+    subs.delete(token);
+    recomputeBufCapacity(pv);
+  };
+}
+
+/** Appends a scalar sample to a PV's history buffer, if any widget has registered interest in it. */
+export function pushPVHistory(pv: string, timeStamp: TimeStamp, value: number): void {
+  const subs = historySubscribers[pv];
+  if (!subs || subs.size === 0) return;
+  const capacity = Math.max(...subs.values());
+  const buf = historyBuffers[pv] ?? (historyBuffers[pv] = []);
+  buf.push([toEpochMillis(timeStamp), value]);
+  if (buf.length > capacity) buf.shift();
+}
+
+/** Returns the current history buffer for a PV (empty array if none recorded). */
+export function getPVHistory(pv: string): ScalarPoint[] {
+  return historyBuffers[pv] ?? [];
+}
+
+/** Clears buffered samples for the given PVs, or all PVs when omitted (subscriptions are left intact). */
+export function clearPVHistory(pvNames?: string[]): void {
+  if (!pvNames) {
+    for (const key of Object.keys(historyBuffers)) historyBuffers[key] = [];
+    return;
+  }
+  for (const pv of pvNames) if (pv in historyBuffers) historyBuffers[pv] = [];
+}


### PR DESCRIPTION
This allows data to be stored independently of rendering cycle, so restarting the plots is no longer needed when plots are not being shown.