### PR TITLE
Handle disconnected PVs

### DIFF
--- a/backend/epicsWS/CAClient.py
+++ b/backend/epicsWS/CAClient.py
@@ -100,18 +100,18 @@ class CAClient:
                     except Exception as e:
                         print(f"[CAClient]: Failed to clear callbacks for {pv_name}: {e}")
 
-    def write_to_pv(self, pv_name: str, value: Any):
+    def write_to_pv(self, pv: str, value: Any):
         """Write synchronously to a PV."""
         with self._lock:
-            pv = self._pvs.get(pv_name)
-        if not pv:
-            print(f"[CAClient]: Cannot write: PV {pv_name} not subscribed.")
+            pv_obj = self._pvs.get(pv)
+        if not pv_obj:
+            print(f"[CAClient]: Cannot write: PV {pv} not subscribed.")
             return
 
         try:
-            pv.put(value)
+            pv_obj.put(value)
         except Exception as e:
-            print(f"[CAClient]: Write to {pv_name} failed: {e}")
+            print(f"[CAClient]: Write to {pv} failed: {e}")
 
     def close(self):
         """Stop all subscriptions and clear resources."""

--- a/backend/epicsWS/CAClient.py
+++ b/backend/epicsWS/CAClient.py
@@ -13,11 +13,13 @@ class CAClient:
     Handles per-client subscriptions and forwards raw callback data to the upper layer.
     """
 
-    def __init__(self, handle_update: Callable[[str, Any], None]):
+    def __init__(self, handle_update: Callable[[str, Any], None], handle_disconnect: Callable[[str], None]):
         """
         handle_update: callable(pv_name: str, raw_data: dict)
+        handle_disconnect: callable(pv_name: str), called when the PV disconnects
         """
         self._handle_update = handle_update
+        self._handle_disconnect = handle_disconnect
         self._pvs: Dict[str, Any] = {}
         self._subscribers: Dict[str, Set[str]] = {}
         self._lock = Lock()
@@ -35,6 +37,11 @@ class CAClient:
 
         self._handle_update(pvname, val)
 
+    def _connection_callback(self, pvname=None, conn=True, **kwargs):
+        """Fires on both connect and disconnect; only disconnect needs forwarding."""
+        if not conn and pvname:
+            self._handle_disconnect(pvname)
+
     def subscribe(self, client_id: str, pv_name: str):
         """
         Subscribe a client to a PV.
@@ -48,7 +55,7 @@ class CAClient:
 
         if first_sub:
             try:
-                pv = epics.get_pv(pv_name)
+                pv = epics.get_pv(pv_name, connection_callback=self._connection_callback)
                 pv.get_ctrlvars()
                 cb = pv.add_callback(self._callback, with_ctrlvars=True)
                 pv.run_callback(cb)

--- a/backend/epicsWS/PVAClient.py
+++ b/backend/epicsWS/PVAClient.py
@@ -4,7 +4,7 @@
 import threading
 from typing import Any, Callable, Dict, Set
 
-from p4p.client.thread import Context, Subscription
+from p4p.client.thread import Cancelled, Context, Disconnected, RemoteError, Subscription
 
 
 class PVAClient:
@@ -12,13 +12,15 @@ class PVAClient:
     Manages PV subscriptions per client_id using p4p.
     """
 
-    def __init__(self, handle_update: Callable[[str, Any], None]):
+    def __init__(self, handle_update: Callable[[str, Any], None], handle_disconnect: Callable[[str], None]):
         """
         handle_update: callable(pv_name: str, value: object)
+        handle_disconnect: callable(pv_name: str), called when the channel disconnects
         """
         self._channels: Dict[str, Subscription] = {}
         self._subscribers: Dict[str, Set[str]] = {}  # pv_name -> set(client_ids)
         self._handle_update = handle_update
+        self._handle_disconnect = handle_disconnect
         self._ctxt = Context("pva", nt=False)  # nt=False to get unpacked data
         self._lock = threading.Lock()
         self._latest_value: Dict[str, Any] = {}  # pv_name -> last value
@@ -27,6 +29,12 @@ class PVAClient:
         """Return a callback for monitor updates."""
 
         def callback(value: Any):
+            # Cancelled fires on our own unsubscribe/close; not a real disconnect
+            if isinstance(value, Cancelled):
+                return
+            if isinstance(value, (Disconnected, RemoteError)):
+                self._handle_disconnect(pv_name)
+                return
             with self._lock:
                 self._latest_value[pv_name] = value
             self._handle_update(pv_name, value)
@@ -37,7 +45,7 @@ class PVAClient:
         """Subscribe a single client to a PV."""
         with self._lock:
             if pv_name not in self._channels:
-                mon = self._ctxt.monitor(pv_name, self._on_update(pv_name))
+                mon = self._ctxt.monitor(pv_name, self._on_update(pv_name), notify_disconnect=True)
                 self._channels[pv_name] = mon
                 self._subscribers[pv_name] = set()
             # Send last value if monitor already existed (late subscriber)

--- a/backend/epicsWS/epicsWS.py
+++ b/backend/epicsWS/epicsWS.py
@@ -51,6 +51,13 @@ def parse_protocol(pv_name: str) -> Tuple[str, str]:
     return DEFAULT_PROTOCOL, pv_name
 
 
+def format_pv_name(pv_name: str, provider: str) -> str:
+    """Re-prefixes a PV name with its protocol, unless it matches the default protocol."""
+    if provider != DEFAULT_PROTOCOL:
+        return f"{provider}://{pv_name}"
+    return pv_name
+
+
 _loop: Optional[asyncio.AbstractEventLoop] = None
 
 
@@ -62,6 +69,20 @@ def ca_callback(pv_name, pv_obj):
 def pva_callback(pv_name, pv_obj):
     if _loop:
         _loop.call_soon_threadsafe(_send_throttled, pv_name, pv_obj, PVA_PROVIDER_KEY)
+
+
+def ca_disconnect_callback(pv_name):
+    if _loop:
+        _loop.call_soon_threadsafe(_schedule_disconnect, pv_name, CA_PROVIDER_KEY)
+
+
+def pva_disconnect_callback(pv_name):
+    if _loop:
+        _loop.call_soon_threadsafe(_schedule_disconnect, pv_name, PVA_PROVIDER_KEY)
+
+
+def _schedule_disconnect(pv_name: str, provider: str):
+    asyncio.create_task(_send_disconnect(pv_name, provider))
 
 
 def _send_throttled(pv_name: str, pv_obj, provider: str):
@@ -129,10 +150,7 @@ async def send_update(pv_name: str, pv_obj, provider: str):
         else:
             _pv_metadata[pv_name] = PVParser.ca_metadata(pv_obj)
 
-    if provider != DEFAULT_PROTOCOL:
-        pv_name_with_provider = f"{provider}://{pv_name}"
-    else:
-        pv_name_with_provider = pv_name
+    pv_name_with_provider = format_pv_name(pv_name, provider)
 
     base_msg = {
         "type": "update",
@@ -160,15 +178,35 @@ async def send_update(pv_name: str, pv_obj, provider: str):
             except Exception:
                 print(f"[epicsWS]: Error sending update to {ws}")
         else:
-            # First update for this client: include metadata
+            # First update for this client (or after a disconnect): include metadata + connected flag
             full_msg = dict(base_msg)
             full_msg.update(_pv_metadata[pv_name])
+            full_msg["connected"] = True
             sent_metadata[key] = True
             data = json.dumps({k: v for k, v in full_msg.items() if v is not None})
             try:
                 await ws.send(data)
             except Exception:
                 print(f"[epicsWS]: Error sending update to {ws}")
+
+
+async def _send_disconnect(pv_name: str, provider: str):
+    """Notifies subscribed clients that a PV has disconnected and forces metadata resend on reconnect."""
+    ws_set = subscriptions.get(pv_name)
+    if not ws_set:
+        return
+
+    msg = {"type": "update", "pv": format_pv_name(pv_name, provider), "connected": False}
+    data = json.dumps(msg)
+
+    for ws in set(ws_set):
+        try:
+            await ws.send(data)
+        except Exception:
+            print(f"[epicsWS]: Error sending disconnect notice to {ws}")
+        sent_metadata[(ws, pv_name)] = False
+
+    _pv_metadata.pop(pv_name, None)
 
 
 async def message_handler(ws: ServerConnection):
@@ -300,8 +338,8 @@ async def main():
     global _loop
     _loop = asyncio.get_running_loop()
 
-    clients[PVA_PROVIDER_KEY] = PVAClient(pva_callback)
-    clients[CA_PROVIDER_KEY] = CAClient(ca_callback)
+    clients[PVA_PROVIDER_KEY] = PVAClient(pva_callback, pva_disconnect_callback)
+    clients[CA_PROVIDER_KEY] = CAClient(ca_callback, ca_disconnect_callback)
 
     async with websockets.serve(message_handler, "0.0.0.0", 8080):
         print("[epicsWS]: WebSocket server running on ws://localhost:8080")

--- a/backend/epicsWS/epicsWS.py
+++ b/backend/epicsWS/epicsWS.py
@@ -249,7 +249,7 @@ async def message_handler(ws: ServerConnection):
                 if pv and value is not None:
                     protocol, pv_name = parse_protocol(pv)
                     client = get_client(protocol)
-                    client.write_to_pv(pv_name, value)
+                    asyncio.create_task(asyncio.to_thread(client.write_to_pv, pv_name, value))
 
             elif msg_type == "snapshot":
                 # Capture current values of all subscribed PVs
@@ -287,18 +287,21 @@ async def message_handler(ws: ServerConnection):
                 )
 
             elif msg_type == "restore":
-                # Write saved PV values back to IOC
                 pvs_to_restore = msg.get("pvs", {})
-                results = []
-                for pv_name, pv_data in pvs_to_restore.items():
+
+                async def _restore_one(pv_name: str, pv_data):
                     try:
                         protocol, clean_name = parse_protocol(pv_name)
                         client = get_client(protocol)
                         value = pv_data if not isinstance(pv_data, dict) else pv_data.get("value")
-                        client.write_to_pv(clean_name, value)
-                        results.append({"pv": pv_name, "success": True})
+                        await asyncio.to_thread(client.write_to_pv, clean_name, value)
+                        return {"pv": pv_name, "success": True}
                     except Exception as e:
-                        results.append({"pv": pv_name, "success": False, "error": str(e)})
+                        return {"pv": pv_name, "success": False, "error": str(e)}
+
+                results = await asyncio.gather(
+                    *(_restore_one(pv_name, pv_data) for pv_name, pv_data in pvs_to_restore.items())
+                )
 
                 await ws.send(
                     json.dumps(

--- a/backend/epicsWS/pvParser.py
+++ b/backend/epicsWS/pvParser.py
@@ -63,6 +63,7 @@ class ValueAlarm:
 @dataclass
 class PVData:
     pv: Optional[str] = None
+    connected: Optional[bool] = False
     value: Optional[Union[float, int, str, List[float], List[int], List[str]]] = None
     enumChoices: Optional[List[str]] = None
     alarm: Optional[Alarm] = None

--- a/src/components/AlarmBorder/AlarmBorder.tsx
+++ b/src/components/AlarmBorder/AlarmBorder.tsx
@@ -22,8 +22,6 @@ const AlarmBorder: React.FC<AlarmBorderProps> = ({ alarmData, children, enable }
   };
 
   const getOutlineColor = (severity: number | undefined): string | undefined => {
-    if (severity === undefined) return COLORS.disconnected;
-
     switch (severity) {
       case 0: // NO_ALARM
         return undefined;
@@ -33,20 +31,32 @@ const AlarmBorder: React.FC<AlarmBorderProps> = ({ alarmData, children, enable }
         return COLORS.major;
       case 3: // INVALID
         return COLORS.invalid;
-      default:
+      default: // disconnected or undefined
         return COLORS.disconnected;
+    }
+  };
+
+  const getOutlineStyle = (severity: number | undefined) => {
+    switch (severity) {
+      case 3: // INVALID
+        return "dashed";
+      case undefined:
+        return "dotted";
+      default:
+        return "solid";
     }
   };
 
   const severity = getWorstSeverity(alarmData);
   const outlineColor = getOutlineColor(severity);
+  const outlineStyle = getOutlineStyle(severity);
 
   const style: CSSProperties = {
     width: "100%",
     height: "100%",
     outlineColor: outlineColor,
     outlineWidth: outlineColor ? "3px" : 0,
-    outlineStyle: outlineColor === COLORS.disconnected ? "dashed" : "solid",
+    outlineStyle: outlineStyle,
     borderRadius: "2px",
     boxSizing: "border-box",
   };

--- a/src/context/useEpicsWS.ts
+++ b/src/context/useEpicsWS.ts
@@ -58,10 +58,18 @@ export default function useEpicsWS(resolvedPVList: string[]) {
    * In case of scalar PVs that have been registered for buffering (plots), push
    * the sample into the history buffer independently of rAF batching so that
    * the history is always up to date even if the widget is not re-rendering.
+   * On disconnect, the PV's cached data and history are purged immediately
+   * instead of merged, so widgets fall back to their "no data" state.
    */
   const onMessage = useCallback((msg: WSMessage) => {
     if (!subscribedRef.current.has(msg.pv)) {
       console.warn(`received message from unsolicited PV: ${msg.pv}`);
+      return;
+    }
+    if (msg.connected === false) {
+      delete pendingPVsRef.current[msg.pv];
+      usePVStore.getState().removePVs([msg.pv]);
+      clearPVHistory([msg.pv]);
       return;
     }
     if (typeof msg.value === "number" && msg.timeStamp) {

--- a/src/types/epicsWS.ts
+++ b/src/types/epicsWS.ts
@@ -123,11 +123,13 @@ export interface PVData {
  * @property type - Type of the message (update, write, subscribe, unsubscribe)
  * @property b64arr - Optional base64-encoded array data
  * @property b64dtype - Optional data type of the base64-encoded array
+ * @property connected - Sent once on (re)connect together with metadata, or as `false` on disconnect
  */
 export interface WSMessage extends PVData {
   type: WSMessageType;
   b64arr?: string;
   b64dtype?: string;
+  connected?: boolean;
 }
 
 /** Collection of PVData objects, keyed by PV name */


### PR DESCRIPTION
Closes #194

So far, 2 major issues related to disconnection existed:

- The WS did not emit messages on disconnection event - this caused the FE to never know if a PV is disconnected or just never received a new value.
   - Fix: created a new optional field "connected". WS sends it as true on first update, together with metadata (only once). On disconnection event, WS emits it as false.
   

- Writing to disconnected or non-existent PVs was not properly handled in the WS, causing freezing of the whole session until timeout was reached.
   - Created a dedicated thread for writing process.