### PR TITLE
Avoid commiting prop changes on every keystroke

### DIFF
--- a/src/components/EditorSidebar/PropertiesTab/Properties/StateListProperty.tsx
+++ b/src/components/EditorSidebar/PropertiesTab/Properties/StateListProperty.tsx
@@ -18,6 +18,26 @@ interface StateListPropertyProps {
 
 const DEFAULT_NEW_STATE: StateEntry = { value: "", color: COLORS.midGray, label: "" };
 
+// Ensure at least 1 normal state + 1 fallback entry in local editing state
+const normalizeStates = (incoming: PropertyValue): StateEntry[] => {
+  if (!Array.isArray(incoming)) {
+    return [{ value: "0", color: COLORS.offColor, label: "" }, { ...DEFAULT_NEW_STATE }];
+  }
+
+  const safeStates = incoming.map((entry) => {
+    const candidate = entry as Partial<StateEntry>;
+    return {
+      value: String(candidate.value ?? ""),
+      color: String(candidate.color ?? COLORS.midGray),
+      label: String(candidate.label ?? ""),
+    } satisfies StateEntry;
+  });
+
+  return safeStates.length >= 2
+    ? safeStates
+    : [{ value: "0", color: COLORS.offColor, label: "" }, { ...DEFAULT_NEW_STATE }];
+};
+
 const StateListProperty: React.FC<StateListPropertyProps> = ({
   propName,
   label,
@@ -26,17 +46,18 @@ const StateListProperty: React.FC<StateListPropertyProps> = ({
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [localStates, setLocalStates] = useState<StateEntry[]>(() => normalizeStates(value));
+
+  React.useEffect(() => {
+    setLocalStates(normalizeStates(value));
+  }, [value]);
 
   if (!Array.isArray(value)) {
     console.warn(`StateListProperty expected StateEntry[], got`, value);
     return null;
   }
 
-  // Ensure at least 1 normal state + 1 fallback entry
-  const states =
-    (value as StateEntry[]).length >= 2
-      ? (value as StateEntry[])
-      : [{ value: "0", color: COLORS.offColor, label: "" }, { ...DEFAULT_NEW_STATE }];
+  const states = localStates;
 
   const fallbackIndex = states.length - 1;
 
@@ -46,6 +67,24 @@ const StateListProperty: React.FC<StateListPropertyProps> = ({
 
   const handleValueChange = (index: number, field: keyof StateEntry, newVal: string) => {
     const newStates = states.map((s, i) => (i === index ? { ...s, [field]: newVal } : s));
+    setLocalStates(newStates);
+  };
+
+  const handleValueCommit = () => {
+    commit(states);
+  };
+
+  const handleColorChange = (newColor: string) => {
+    if (activeIndex === null) return;
+    const newStates = states.map((s, i) =>
+      i === activeIndex
+        ? {
+            ...s,
+            color: newColor,
+          }
+        : s,
+    );
+    setLocalStates(newStates);
     commit(newStates);
   };
 
@@ -59,21 +98,18 @@ const StateListProperty: React.FC<StateListPropertyProps> = ({
     setActiveIndex(null);
   };
 
-  const handleColorChange = (newColor: string) => {
-    if (activeIndex === null) return;
-    handleValueChange(activeIndex, "color", newColor);
-  };
-
   const handleAdd = (index: number, isFallback: boolean) => {
     const newStates = [...states];
     // For the fallback row, insert before it; otherwise insert after
     const insertAt = isFallback ? index : index + 1;
     newStates.splice(insertAt, 0, { ...DEFAULT_NEW_STATE });
+    setLocalStates(newStates);
     commit(newStates);
   };
 
   const handleRemove = (index: number) => {
     const newStates = states.filter((_, i) => i !== index);
+    setLocalStates(newStates);
     commit(newStates);
   };
 
@@ -115,6 +151,13 @@ const StateListProperty: React.FC<StateListPropertyProps> = ({
                     label="Value"
                     value={state.value}
                     onChange={(e) => handleValueChange(index, "value", e.target.value)}
+                    onBlur={handleValueCommit}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleValueCommit();
+                      }
+                    }}
                     sx={{ flex: 1, minWidth: 0 }}
                     slotProps={{ htmlInput: { style: { fontSize: 12 } } }}
                   />
@@ -143,6 +186,13 @@ const StateListProperty: React.FC<StateListPropertyProps> = ({
               label="Label"
               value={state.label}
               onChange={(e) => handleValueChange(index, "label", e.target.value)}
+              onBlur={handleValueCommit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleValueCommit();
+                }
+              }}
               sx={{ flex: 1, minWidth: 0 }}
               slotProps={{ htmlInput: { style: { fontSize: 12 } } }}
             />

--- a/src/components/EditorSidebar/PropertiesTab/Properties/StrListProperty.tsx
+++ b/src/components/EditorSidebar/PropertiesTab/Properties/StrListProperty.tsx
@@ -18,38 +18,63 @@ interface StrListPropertyProps {
 }
 
 const StrListProperty: React.FC<StrListPropertyProps> = ({ propName, label, value, onChange }) => {
-  if (!Array.isArray(value)) {
-    console.warn(`StrListProperty expected string[], got`, value);
-    return null;
-  }
+  const normalizeItems = React.useCallback((incoming: PropertyValue): string[] => {
+    if (!Array.isArray(incoming)) {
+      return [""];
+    }
+    const normalized = incoming.map((item) => (typeof item === "string" ? item : ""));
+    return normalized.length > 0 ? normalized : [""];
+  }, []);
 
-  const strValue = value as string[];
-  const items = strValue.length > 0 ? strValue : [""];
+  const [localItems, setLocalItems] = React.useState<string[]>(() => normalizeItems(value));
+
+  React.useEffect(() => {
+    setLocalItems(normalizeItems(value));
+  }, [normalizeItems, value]);
+
+  const commitItems = React.useCallback(
+    (newItems: string[]) => {
+      onChange(propName, newItems);
+    },
+    [onChange, propName],
+  );
 
   const handleChange = (index: number, newVal: string) => {
-    const newArr = [...items];
+    const newArr = [...localItems];
     newArr[index] = newVal;
-    onChange(propName, newArr);
+    setLocalItems(newArr);
+  };
+
+  const handleCommit = () => {
+    commitItems(localItems);
   };
 
   const handleAdd = (index?: number) => {
-    const newArr = [...items];
+    const newArr = [...localItems];
     if (typeof index === "number") {
       newArr.splice(index + 1, 0, "");
     } else {
       newArr.push("");
     }
-    onChange(propName, newArr);
+    setLocalItems(newArr);
+    commitItems(newArr);
   };
 
   const handleRemove = (index: number) => {
-    const newArr = items.filter((_, i) => i !== index);
-    onChange(propName, newArr.length > 0 ? newArr : [""]);
+    const newArr = localItems.filter((_, i) => i !== index);
+    const ensured = newArr.length > 0 ? newArr : [""];
+    setLocalItems(ensured);
+    commitItems(ensured);
   };
+
+  if (!Array.isArray(value)) {
+    console.warn(`StrListProperty expected string[], got`, value);
+    return null;
+  }
 
   return (
     <>
-      {items.map((val, index) => (
+      {localItems.map((val, index) => (
         <ListItem
           key={index}
           disablePadding
@@ -62,6 +87,13 @@ const StrListProperty: React.FC<StrListPropertyProps> = ({ propName, label, valu
             label={`${label} ${index}`}
             value={val}
             onChange={(e) => handleChange(index, e.target.value)}
+            onBlur={handleCommit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleCommit();
+              }
+            }}
           />
           <IconButton color="primary" onClick={() => handleAdd(index)}>
             <AddIcon />
@@ -69,7 +101,7 @@ const StrListProperty: React.FC<StrListPropertyProps> = ({ propName, label, valu
           <IconButton
             color="error"
             onClick={() => handleRemove(index)}
-            disabled={items.length === 1}
+            disabled={localItems.length === 1}
           >
             <RemoveIcon />
           </IconButton>

--- a/src/components/EditorSidebar/PropertiesTab/Properties/StrRecordProperty.tsx
+++ b/src/components/EditorSidebar/PropertiesTab/Properties/StrRecordProperty.tsx
@@ -17,70 +17,96 @@ interface StrRecordPropertyProps {
   onChange: (propName: PropertyKey, newValue: PropertyValue) => void;
 }
 
+type StrPair = [string, string];
+
 const StrRecordProperty: React.FC<StrRecordPropertyProps> = ({
   propName,
   label,
   value,
   onChange,
 }) => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    console.warn(`StrRecordProperty expected Record<string,string>, got`, value);
-    return null;
-  }
+  const normalizeItems = React.useCallback((record: PropertyValue): StrPair[] => {
+    if (typeof record !== "object" || record === null || Array.isArray(record)) {
+      return [["", ""]];
+    }
 
-  const entries = Object.entries(value);
-  const items = entries.length > 0 ? entries : [["", ""]];
+    const entries = Object.entries(record).map(([k, v]) => [k, String(v)] as StrPair);
+    return entries.length > 0 ? entries : [["", ""]];
+  }, []);
+
+  const [localItems, setLocalItems] = React.useState<StrPair[]>(() => normalizeItems(value));
+
+  React.useEffect(() => {
+    setLocalItems(normalizeItems(value));
+  }, [normalizeItems, value]);
+
+  const commitItems = React.useCallback(
+    (newItems: StrPair[]) => {
+      onChange(propName, Object.fromEntries(newItems));
+    },
+    [onChange, propName],
+  );
+
+  const normalizeKey = React.useCallback((key: string) => {
+    if (!key.trim()) return key;
+    if (/^\$\(.+\)$/.test(key)) return key;
+    return `$(${key})`;
+  }, []);
 
   const handleKeyChange = (index: number, newKey: string) => {
-    const newEntries = [...items];
+    const newEntries = [...localItems];
     const [, val] = newEntries[index];
     newEntries[index] = [newKey, val];
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    onChange(propName, Object.fromEntries(newEntries));
+    setLocalItems(newEntries);
   };
 
-  const handleKeyBlur = (index: number) => {
-    const entries = Object.entries(value);
-    const [key, val] = entries[index];
-    if (!key.trim()) return;
-
-    // wrap if not already $(KEY)
-    if (!/^\$\(.+\)$/.test(key)) {
-      const wrappedKey = `$(${key})`;
-      const newEntries = [...entries];
-      newEntries[index] = [wrappedKey, val];
-      onChange(propName, Object.fromEntries(newEntries));
-    }
+  const handleKeyCommit = (index: number) => {
+    const newEntries = [...localItems];
+    const [key, val] = newEntries[index];
+    const wrappedKey = normalizeKey(key);
+    newEntries[index] = [wrappedKey, val];
+    setLocalItems(newEntries);
+    commitItems(newEntries);
   };
 
   const handleValueChange = (index: number, newVal: string) => {
-    const newEntries = [...items];
+    const newEntries = [...localItems];
     const [key] = newEntries[index];
     newEntries[index] = [key, newVal];
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    onChange(propName, Object.fromEntries(newEntries));
+    setLocalItems(newEntries);
+  };
+
+  const handleValueCommit = () => {
+    const newEntries = [...localItems];
+    commitItems(newEntries);
   };
 
   const handleAdd = (index?: number) => {
-    const newEntries = [...items];
+    const newEntries = [...localItems];
     if (typeof index === "number") {
       newEntries.splice(index + 1, 0, ["", ""]);
     } else {
       newEntries.push(["", ""]);
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    onChange(propName, Object.fromEntries(newEntries));
+    setLocalItems(newEntries);
+    commitItems(newEntries);
   };
 
   const handleRemove = (index: number) => {
-    const newEntries = items.filter((_, i) => i !== index);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    onChange(propName, Object.fromEntries(newEntries.length > 0 ? newEntries : [["", ""]]));
+    const newEntries = localItems.filter((_, i) => i !== index);
+    const ensuredEntries: StrPair[] = newEntries.length > 0 ? newEntries : [["", ""]];
+    setLocalItems(ensuredEntries);
+    commitItems(ensuredEntries);
   };
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    console.warn(`StrRecordProperty expected Record<string,string>, got`, value);
+    return null;
+  }
 
   return (
     <>
-      {items.map(([key, val], index) => (
+      {localItems.map(([key, val], index) => (
         <ListItem
           key={index}
           disablePadding
@@ -92,7 +118,13 @@ const StrRecordProperty: React.FC<StrRecordPropertyProps> = ({
             label={`${label} ${index}`}
             value={key}
             onChange={(e) => handleKeyChange(index, e.target.value)}
-            onBlur={() => handleKeyBlur(index)}
+            onBlur={() => handleKeyCommit(index)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleKeyCommit(index);
+              }
+            }}
             sx={{ flex: 1 }}
           />
           <TextField
@@ -100,6 +132,13 @@ const StrRecordProperty: React.FC<StrRecordPropertyProps> = ({
             label="Value"
             value={val}
             onChange={(e) => handleValueChange(index, e.target.value)}
+            onBlur={handleValueCommit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleValueCommit();
+              }
+            }}
             sx={{ flex: 1 }}
           />
           <IconButton color="primary" onClick={() => handleAdd(index)}>
@@ -108,7 +147,7 @@ const StrRecordProperty: React.FC<StrRecordPropertyProps> = ({
           <IconButton
             color="error"
             onClick={() => handleRemove(index)}
-            disabled={items.length === 1}
+            disabled={localItems.length === 1}
           >
             <RemoveIcon />
           </IconButton>


### PR DESCRIPTION
This was already handled in some properties, but StrList, StateList and StrRecord were still committing immediately.
This commit makes it so that they only commit to state on blur or when pressing Enter.

Closes #195 